### PR TITLE
Fix self-following crash

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/domain/usecase/profile/FollowUserUseCase.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/domain/usecase/profile/FollowUserUseCase.kt
@@ -5,9 +5,9 @@ import javax.inject.Inject
 
 class FollowUserUseCase @Inject constructor(private val repository: ProfileRepository) {
     suspend operator fun invoke(userId: String, targetUserId: String): Result<Unit> {
-        require(userId.isNotBlank()) { "User ID cannot be blank" }
-        require(targetUserId.isNotBlank()) { "Target user ID cannot be blank" }
-        require(userId != targetUserId) { "Cannot follow yourself" }
+        if (userId.isBlank()) return Result.failure(IllegalArgumentException("User ID cannot be blank"))
+        if (targetUserId.isBlank()) return Result.failure(IllegalArgumentException("Target user ID cannot be blank"))
+        if (userId == targetUserId) return Result.failure(IllegalArgumentException("Cannot follow yourself"))
         return repository.followUser(userId, targetUserId)
     }
 }

--- a/app/src/main/java/com/synapse/social/studioasinc/domain/usecase/profile/UnfollowUserUseCase.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/domain/usecase/profile/UnfollowUserUseCase.kt
@@ -7,6 +7,7 @@ class UnfollowUserUseCase @Inject constructor(private val repository: ProfileRep
     suspend operator fun invoke(userId: String, targetUserId: String): Result<Unit> {
         if (userId.isBlank()) return Result.failure(IllegalArgumentException("User ID cannot be blank"))
         if (targetUserId.isBlank()) return Result.failure(IllegalArgumentException("Target user ID cannot be blank"))
+        if (userId == targetUserId) return Result.failure(IllegalArgumentException("Cannot unfollow yourself"))
         return repository.unfollowUser(userId, targetUserId)
     }
 }

--- a/app/src/main/java/com/synapse/social/studioasinc/domain/usecase/profile/UnfollowUserUseCase.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/domain/usecase/profile/UnfollowUserUseCase.kt
@@ -5,8 +5,8 @@ import javax.inject.Inject
 
 class UnfollowUserUseCase @Inject constructor(private val repository: ProfileRepository) {
     suspend operator fun invoke(userId: String, targetUserId: String): Result<Unit> {
-        require(userId.isNotBlank()) { "User ID cannot be blank" }
-        require(targetUserId.isNotBlank()) { "Target user ID cannot be blank" }
+        if (userId.isBlank()) return Result.failure(IllegalArgumentException("User ID cannot be blank"))
+        if (targetUserId.isBlank()) return Result.failure(IllegalArgumentException("Target user ID cannot be blank"))
         return repository.unfollowUser(userId, targetUserId)
     }
 }

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/ProfileViewModel.kt
@@ -202,7 +202,7 @@ class ProfileViewModel @Inject constructor(
     fun followUser(userId: String) {
         viewModelScope.launch {
             val currentUserId = _state.value.currentUserId
-            if (currentUserId == userId) return@launch
+            if (currentUserId.isBlank() || currentUserId == userId) return@launch
 
             _state.update { it.copy(isFollowLoading = true) }
             followUserUseCase(currentUserId, userId).onSuccess {
@@ -216,7 +216,7 @@ class ProfileViewModel @Inject constructor(
     fun unfollowUser(userId: String) {
          viewModelScope.launch {
             val currentUserId = _state.value.currentUserId
-            if (currentUserId == userId) return@launch
+            if (currentUserId.isBlank() || currentUserId == userId) return@launch
 
             _state.update { it.copy(isFollowLoading = true) }
             unfollowUserUseCase(currentUserId, userId).onSuccess {

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/ProfileViewModel.kt
@@ -202,6 +202,8 @@ class ProfileViewModel @Inject constructor(
     fun followUser(userId: String) {
         viewModelScope.launch {
             val currentUserId = _state.value.currentUserId
+            if (currentUserId == userId) return@launch
+
             _state.update { it.copy(isFollowLoading = true) }
             followUserUseCase(currentUserId, userId).onSuccess {
                 _state.update { it.copy(isFollowing = true, isFollowLoading = false) }
@@ -214,6 +216,8 @@ class ProfileViewModel @Inject constructor(
     fun unfollowUser(userId: String) {
          viewModelScope.launch {
             val currentUserId = _state.value.currentUserId
+            if (currentUserId == userId) return@launch
+
             _state.update { it.copy(isFollowLoading = true) }
             unfollowUserUseCase(currentUserId, userId).onSuccess {
                 _state.update { it.copy(isFollowing = false, isFollowLoading = false) }


### PR DESCRIPTION
This fixes a crash by preventing the followUser and unfollowUser actions in ProfileViewModel from firing if the current user ID matches the target user ID. It also modifies the FollowUserUseCase and UnfollowUserUseCase to return a Result.failure rather than hard crashing via require() blocks when validations fail.

---
*PR created automatically by Jules for task [7935280805846216368](https://jules.google.com/task/7935280805846216368) started by @TheRealAshik*