### PR TITLE
✨ feat: 1:1 crop interface before avatar upload on Edit Profile

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -221,6 +221,9 @@
 		<activity
             android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
             android:theme="@style/Base.Theme.AppCompat" />
+		<activity
+			android:name="com.canhub.cropper.CropImageActivity"
+			android:theme="@style/Base.Theme.AppCompat" />
 		<provider
 			android:name="androidx.startup.InitializationProvider"
 			android:authorities="com.synapse.social.studioasinc.androidx-startup"

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/editprofile/EditProfileScreen.kt
@@ -41,6 +41,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.canhub.cropper.CropImageContract
+import com.canhub.cropper.CropImageContractOptions
+import com.canhub.cropper.CropImageOptions
 import com.synapse.social.studioasinc.R
 import com.synapse.social.studioasinc.CreatePostActivity
 import com.synapse.social.studioasinc.presentation.editprofile.components.EditProfileContent
@@ -67,11 +70,27 @@ fun EditProfileScreen(
     val context = LocalContext.current
 
 
+    val cropLauncher = rememberLauncherForActivityResult(CropImageContract()) { result ->
+        if (result.isSuccessful) {
+            result.uriContent?.let { viewModel.onEvent(EditProfileEvent.AvatarCropped(it)) }
+        }
+    }
+
     val avatarPicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia()
     ) { uri ->
         if (uri != null) {
             viewModel.onEvent(EditProfileEvent.AvatarSelected(uri))
+            cropLauncher.launch(
+                CropImageContractOptions(
+                    uri = uri,
+                    cropImageOptions = CropImageOptions(
+                        aspectRatioX = 1,
+                        aspectRatioY = 1,
+                        fixAspectRatio = true
+                    )
+                )
+            )
         }
     }
 

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/editprofile/EditProfileUiState.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/editprofile/EditProfileUiState.kt
@@ -11,6 +11,7 @@ data class EditProfileUiState(
     val profile: UserProfile? = null,
     val avatarUrl: String? = null,
     val coverUrl: String? = null,
+    val pendingAvatarUri: Uri? = null,
     val avatarUploadState: UploadState = UploadState.Idle,
     val coverUploadState: UploadState = UploadState.Idle,
     val username: String = "",
@@ -60,6 +61,7 @@ sealed class EditProfileEvent {
     data class GenderSelected(val gender: Gender) : EditProfileEvent()
     data class RegionSelected(val region: String) : EditProfileEvent()
     data class AvatarSelected(val uri: Uri) : EditProfileEvent()
+    data class AvatarCropped(val uri: Uri) : EditProfileEvent()
     data class CoverSelected(val uri: Uri) : EditProfileEvent()
     object RetryAvatarUpload : EditProfileEvent()
     object RetryCoverUpload : EditProfileEvent()

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/editprofile/EditProfileViewModel.kt
@@ -110,6 +110,9 @@ class EditProfileViewModel @Inject constructor(
             is EditProfileEvent.AvatarSelected -> {
                 handleAvatarSelection(event.uri)
             }
+            is EditProfileEvent.AvatarCropped -> {
+                _uiState.update { it.copy(pendingAvatarUri = event.uri, hasChanges = true, avatarUploadState = UploadState.Idle) }
+            }
             is EditProfileEvent.CoverSelected -> {
                 handleCoverSelection(event.uri)
             }
@@ -222,70 +225,60 @@ class EditProfileViewModel @Inject constructor(
 
     private fun handleAvatarSelection(uri: Uri) {
         lastAvatarUri = uri
-        _uiState.update { it.copy(avatarUploadState = UploadState.Uploading()) }
-
-        viewModelScope.launch {
-            try {
-                val context = getApplication<Application>()
-                android.util.Log.d("EditProfile", "Processing avatar URI: $uri")
-
-
-                var realFilePath = UriUtils.getPathFromUri(context, uri)
-                android.util.Log.d("EditProfile", "Converted file path: $realFilePath")
-
-
-                if (realFilePath == null) {
-                    android.util.Log.d("EditProfile", "URI conversion failed, copying content to temp file")
-                    val tempInputFile = File(context.cacheDir, "temp_input_avatar_${System.currentTimeMillis()}.jpg")
-
-                    context.contentResolver.openInputStream(uri)?.use { inputStream ->
-                        tempInputFile.outputStream().use { outputStream ->
-                            inputStream.copyTo(outputStream)
-                        }
-                    }
-
-                    if (tempInputFile.exists() && tempInputFile.length() > 0) {
-                        realFilePath = tempInputFile.absolutePath
-                        android.util.Log.d("EditProfile", "Successfully copied to temp file: $realFilePath")
-                    } else {
-                        throw Exception("Failed to copy image content from URI")
-                    }
-                }
-
-
-                val sourceFile = File(realFilePath)
-                if (!sourceFile.exists()) {
-                    throw Exception("Source file does not exist: $realFilePath")
-                }
-                if (sourceFile.length() == 0L) {
-                    throw Exception("Source file is empty: $realFilePath")
-                }
-
-
-                val tempFile = File(context.cacheDir, "temp_avatar_${System.currentTimeMillis()}.jpg")
-                android.util.Log.d("EditProfile", "Compressing image to: ${tempFile.absolutePath}")
-
-                ImageUtils.resizeBitmapFileRetainRatio(realFilePath, tempFile.absolutePath, 1024)
-
-
-                if (!tempFile.exists() || tempFile.length() == 0L) {
-                    throw Exception("Image compression failed")
-                }
-
-                android.util.Log.d("EditProfile", "Image compressed successfully, size: ${tempFile.length()} bytes")
-
-
-                uploadAvatar(tempFile.absolutePath)
-
-            } catch (e: Exception) {
-                android.util.Log.e("EditProfile", "Avatar processing failed", e)
-                _uiState.update {
-                    it.copy(avatarUploadState = UploadState.Error("Failed to process image: ${e.message}"))
-                }
-            }
-        }
     }
 
+    private suspend fun compressAndUploadAvatar(uri: Uri): Result<String> {
+        val context = getApplication<Application>()
+        android.util.Log.d("EditProfile", "Processing avatar URI: $uri")
+
+        var realFilePath = UriUtils.getPathFromUri(context, uri)
+        android.util.Log.d("EditProfile", "Converted file path: $realFilePath")
+
+        if (realFilePath == null) {
+            android.util.Log.d("EditProfile", "URI conversion failed, copying content to temp file")
+            val tempInputFile = File(context.cacheDir, "temp_input_avatar_${System.currentTimeMillis()}.jpg")
+
+            context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                tempInputFile.outputStream().use { outputStream ->
+                    inputStream.copyTo(outputStream)
+                }
+            }
+
+            if (tempInputFile.exists() && tempInputFile.length() > 0) {
+                realFilePath = tempInputFile.absolutePath
+                android.util.Log.d("EditProfile", "Successfully copied to temp file: $realFilePath")
+            } else {
+                return Result.failure(Exception("Failed to copy image content from URI"))
+            }
+        }
+
+        val sourceFile = File(realFilePath)
+        if (!sourceFile.exists()) {
+            return Result.failure(Exception("Source file does not exist: $realFilePath"))
+        }
+        if (sourceFile.length() == 0L) {
+            return Result.failure(Exception("Source file is empty: $realFilePath"))
+        }
+
+        val tempFile = File(context.cacheDir, "temp_avatar_${System.currentTimeMillis()}.jpg")
+        android.util.Log.d("EditProfile", "Compressing image to: ${tempFile.absolutePath}")
+
+        ImageUtils.resizeBitmapFileRetainRatio(realFilePath, tempFile.absolutePath, 1024)
+
+        if (!tempFile.exists() || tempFile.length() == 0L) {
+            return Result.failure(Exception("Image compression failed"))
+        }
+
+        android.util.Log.d("EditProfile", "Image compressed successfully, size: ${tempFile.length()} bytes")
+
+        val userId = repository.getCurrentUserId()
+            ?: return Result.failure(Exception("User not logged in"))
+
+        android.util.Log.d("EditProfile", "Starting avatar upload for user: $userId, file: ${tempFile.absolutePath}")
+        return repository.uploadAvatar(userId, tempFile.absolutePath)
+    }
+
+    @Deprecated("Logic moved to compressAndUploadAvatar and saveProfile")
     private fun uploadAvatar(filePath: String) {
         viewModelScope.launch {
             try {
@@ -455,7 +448,7 @@ class EditProfileViewModel @Inject constructor(
 
     private fun retryAvatarUpload() {
         lastAvatarUri?.let { uri ->
-            handleAvatarSelection(uri)
+            onEvent(EditProfileEvent.AvatarCropped(uri))
         }
     }
 
@@ -482,12 +475,47 @@ class EditProfileViewModel @Inject constructor(
             }
 
             try {
-                val updateData = buildUpdateDataMap(state)
+                var finalState = state
+                if (state.pendingAvatarUri != null) {
+                    _uiState.update { it.copy(avatarUploadState = UploadState.Uploading()) }
+                    val uploadResult = compressAndUploadAvatar(state.pendingAvatarUri)
+                    uploadResult.fold(
+                        onSuccess = { url ->
+                            android.util.Log.d("EditProfile", "Avatar upload successful: $url")
+                            _uiState.update {
+                                it.copy(
+                                    avatarUrl = url,
+                                    avatarUploadState = UploadState.Success,
+                                    pendingAvatarUri = null,
+                                    showShareToFeedDialog = true
+                                )
+                            }
+                            finalState = _uiState.value
+                            try {
+                                repository.addToProfileHistory(userId, url)
+                            } catch (e: Exception) {
+                                android.util.Log.w("EditProfile", "Failed to add to profile history", e)
+                            }
+                        },
+                        onFailure = { error ->
+                            android.util.Log.e("EditProfile", "Avatar upload failed", error)
+                            _uiState.update {
+                                it.copy(
+                                    avatarUploadState = UploadState.Error("Avatar upload failed: ${error.message}"),
+                                    isSaving = false
+                                )
+                            }
+                            return@launch
+                        }
+                    )
+                }
+
+                val updateData = buildUpdateDataMap(finalState)
                 val result = repository.updateProfile(userId, updateData)
 
                 result.fold(
                     onSuccess = {
-                        handleSuccessfulSave(state, userId)
+                        handleSuccessfulSave(finalState, userId)
                     },
                     onFailure = { error ->
                         _uiState.update { it.copy(isSaving = false, error = "Failed to save: ${error.message}") }

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/editprofile/components/EditProfileContent.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/editprofile/components/EditProfileContent.kt
@@ -39,6 +39,7 @@ fun EditProfileContent(
             ProfileImageSection(
                 coverUrl = uiState.coverUrl,
                 avatarUrl = uiState.avatarUrl,
+                pendingAvatarUri = uiState.pendingAvatarUri,
                 avatarUploadState = uiState.avatarUploadState,
                 coverUploadState = uiState.coverUploadState,
                 onCoverClick = onCoverClick,

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/editprofile/components/ProfileImageSection.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/editprofile/components/ProfileImageSection.kt
@@ -52,6 +52,7 @@ import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 fun ProfileImageSection(
     coverUrl: String?,
     avatarUrl: String?,
+    pendingAvatarUri: android.net.Uri? = null,
     avatarUploadState: com.synapse.social.studioasinc.presentation.editprofile.UploadState,
     coverUploadState: com.synapse.social.studioasinc.presentation.editprofile.UploadState,
     onCoverClick: () -> Unit,
@@ -168,10 +169,18 @@ fun ProfileImageSection(
                         color = MaterialTheme.colorScheme.surface,
                         modifier = Modifier.fillMaxSize()
                     ) {
-                        if (avatarUrl != null && avatarUrl.isNotBlank()) {
-                            android.util.Log.d("ProfileImageSection", "Loading avatar from URL: $avatarUrl")
+                        val model = when {
+                            pendingAvatarUri != null -> pendingAvatarUri
+                            avatarUrl != null && avatarUrl.isNotBlank() -> ImageLoader.buildImageRequest(LocalContext.current, avatarUrl)
+                            else -> null
+                        }
+
+                        if (model != null) {
+                            if (avatarUrl != null && avatarUrl.isNotBlank()) {
+                                android.util.Log.d("ProfileImageSection", "Loading avatar from URL: $avatarUrl")
+                            }
                             AsyncImage(
-                                model = ImageLoader.buildImageRequest(LocalContext.current, avatarUrl),
+                                model = model,
                                 contentDescription = "Profile photo",
                                 modifier = Modifier.fillMaxSize(),
                                 contentScale = ContentScale.Crop


### PR DESCRIPTION
**What:** Inserts a full-screen 1:1 crop step after avatar selection; shows local preview immediately; defers upload to Save.
**Why:** Ensures profile pictures are always square before upload, improving visual consistency across the app.

---
*PR created automatically by Jules for task [11852354204197688111](https://jules.google.com/task/11852354204197688111) started by @TheRealAshik*