### PR TITLE
Fix Supabase Realtime rate limiting and message_reactions constraint

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/data/repository/ReactionRepositoryImpl.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/repository/ReactionRepositoryImpl.kt
@@ -22,6 +22,8 @@ import io.github.jan.supabase.postgrest.rpc
 import com.synapse.social.studioasinc.domain.repository.ReactionToggleResult
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
+import io.github.jan.supabase.exceptions.HttpRequestException
+import io.github.jan.supabase.postgrest.exception.PostgrestRestException
 
 
 
@@ -79,10 +81,13 @@ class ReactionRepositoryImpl @Inject constructor(
                          return@withContext Result.success(ReactionToggleResult.UPDATED)
                      }
                 } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-                     Log.w(TAG, "Optimized toggle failed, falling back to standard Check-Then-Act: ${e.message}")
-                     // Fallthrough to standard logic
+                    throw e
+                } catch (e: HttpRequestException) {
+                    Log.w(TAG, "Network error during optimized toggle: ${e.message}")
+                } catch (e: PostgrestRestException) {
+                    Log.w(TAG, "Database error during optimized toggle: ${e.message}")
+                } catch (e: Exception) {
+                    Log.w(TAG, "Optimized toggle failed: ${e.message}")
                 }
             }
 
@@ -124,12 +129,21 @@ class ReactionRepositoryImpl @Inject constructor(
                     }
 
                     return@withContext Result.success(result)
-                } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
+                } catch (e: HttpRequestException) {
+                    lastException = e
+                    if (attempt == MAX_RETRIES - 1) throw e
+                    Log.w(TAG, "Network error (attempt ${attempt + 1}): ${e.message}")
+                    delay(RETRY_DELAY_MS * (attempt + 1))
+                } catch (e: PostgrestRestException) {
                     lastException = e
                     val isRLSError = e.message?.contains("policy", true) == true
                     if (isRLSError || attempt == MAX_RETRIES - 1) throw e
+                    Log.w(TAG, "Database error (attempt ${attempt + 1}): ${e.message}")
+                    delay(RETRY_DELAY_MS * (attempt + 1))
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    lastException = e
+                    if (attempt == MAX_RETRIES - 1) throw e
                     delay(RETRY_DELAY_MS * (attempt + 1))
                 }
             }

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/ChatInputDelegate.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/ChatInputDelegate.kt
@@ -28,21 +28,25 @@ class ChatInputDelegate(
     private val onChatRefreshRequired: () -> Unit
 ) {
     private var typingDebounceJob: Job? = null
+    private var isCurrentlyTyping = false
 
     fun onInputTextChange(newText: String) {
         _inputText.value = newText
 
         val chatId = currentChatIdProvider() ?: return
 
-        typingDebounceJob?.cancel()
-
-        viewModelScope.launch {
-            broadcastTypingStatusUseCase(chatId, true)
+        if (!isCurrentlyTyping) {
+            isCurrentlyTyping = true
+            viewModelScope.launch {
+                broadcastTypingStatusUseCase(chatId, true)
+            }
         }
 
+        typingDebounceJob?.cancel()
         typingDebounceJob = viewModelScope.launch {
-            delay(2000)
+            delay(3000)
             broadcastTypingStatusUseCase(chatId, false)
+            isCurrentlyTyping = false
         }
     }
 


### PR DESCRIPTION
This PR addresses two main issues identified in the logs:
1. 'Client presence rate limit exceeded': Fixed by implementing a debouncing mechanism in `ChatInputDelegate.kt` for typing status broadcasts. It now only sends 'typing = true' if the user wasn't already typing, and 'typing = false' after 3 seconds of inactivity.
2. 'null value in column "created_at" violates not-null constraint' for `message_reactions`: Fixed by applying a database migration that sets `now()` as the default value for both `created_at` and `updated_at` columns in the `message_reactions` table.
Additionally, `ReactionRepositoryImpl.kt` was updated with more robust error handling for Supabase-specific exceptions.

---
*PR created automatically by Jules for task [16265459363381217495](https://jules.google.com/task/16265459363381217495) started by @TheRealAshik*