### PR TITLE
fix: Use MaterialTheme colors in MessageContextMenu

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageContextMenu.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageContextMenu.kt
@@ -82,7 +82,7 @@ fun MessageContextMenu(
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        containerColor = Color(0xFF1A1A1A)
+        containerColor = MaterialTheme.colorScheme.surface
     ) {
         Column(
             modifier = Modifier
@@ -101,7 +101,7 @@ fun MessageContextMenu(
                         contentAlignment = Alignment.Center,
                         modifier = Modifier
                             .size(56.dp)
-                            .background(color = Color(0xFF2C2C2C), shape = CircleShape)
+                            .background(color = MaterialTheme.colorScheme.surfaceVariant, shape = CircleShape)
                             .clickable {
                                 val sharedReaction = SharedReactionType.fromString(reaction.name)
                                 selectedMessage.id?.let { onReactionSelected(it, sharedReaction) }


### PR DESCRIPTION
Fixed an issue where the message context menu (bottom sheet) appeared blank or illegible because of hardcoded dark colors that did not adapt to the system's theme. The container color and reaction background colors in MessageContextMenu.kt were using hardcoded hex values (0xFF1A1A1A and 0xFF2C2C2C). These have been replaced with MaterialTheme.colorScheme.surface and MaterialTheme.colorScheme.surfaceVariant to ensure proper visibility in both light and dark modes.

---
*PR created automatically by Jules for task [903856051794084704](https://jules.google.com/task/903856051794084704) started by @TheRealAshik*