### PR TITLE
Refactor ProfileScreen loading state to granular shimmer

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/ProfileContentSection.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/ProfileContentSection.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.widget.Toast
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -31,11 +32,14 @@ import com.synapse.social.studioasinc.feature.shared.components.post.SharedPostI
 import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 import com.synapse.social.studioasinc.ui.components.EmptyState
 import kotlinx.coroutines.delay
+import com.synapse.social.studioasinc.shared.domain.model.MediaType
+import com.synapse.social.studioasinc.shared.domain.model.MediaItem as DomainMediaItem
 
 @Composable
 internal fun ProfileContent(
     state: ProfileScreenState,
-    profile: com.synapse.social.studioasinc.data.model.UserProfile,
+    profile: com.synapse.social.studioasinc.data.model.UserProfile?,
+    isLoading: Boolean,
     listState: androidx.compose.foundation.lazy.LazyListState,
     scrollProgress: Float,
     viewModel: ProfileViewModel,
@@ -116,113 +120,130 @@ internal fun ProfileContent(
         }
 
         item {
-            ProfileHeader(
-                avatar = profile.avatar,
-                status = profile.status,
-                coverImageUrl = profile.coverImageUrl,
-                name = profile.name,
-                username = profile.username,
-                nickname = profile.nickname,
-                bio = profile.bio,
-                isVerified = profile.isVerified,
-                hasStory = state.hasStory,
-                postsCount = profile.postCount,
-                followersCount = profile.followerCount,
-                followingCount = profile.followingCount,
-                isOwnProfile = state.isOwnProfile && state.viewAsMode == null,
-                isFollowing = state.isFollowing,
-                isFollowLoading = state.isFollowLoading,
-                scrollOffset = scrollProgress,
-                bioExpanded = bioExpanded,
-                onToggleBio = { bioExpanded = !bioExpanded },
-                onProfileImageClick = {
-                     if (state.isOwnProfile) {
-                         onNavigateToEditProfile()
-                     } else if (!profile.avatar.isNullOrBlank()) {
-                         onOpenMediaViewer(listOf(profile.avatar), 0)
-                     }
-                },
-                onCoverPhotoClick = {
-                     if (state.isOwnProfile) {
-                         onNavigateToEditProfile()
-                     } else if (!profile.coverImageUrl.isNullOrBlank()) {
-                         onOpenMediaViewer(listOf(profile.coverImageUrl), 0)
-                     }
-                },
-                onEditProfileClick = onNavigateToEditProfile,
-                onFollowClick = {
-                    if (state.isFollowing) {
-                        viewModel.unfollowUser(profile.id)
-                    } else {
-                        viewModel.followUser(profile.id)
+            if (profile != null) {
+                ProfileHeader(
+                    avatar = profile.avatar,
+                    status = profile.status,
+                    coverImageUrl = profile.coverImageUrl,
+                    name = profile.name,
+                    username = profile.username,
+                    nickname = profile.nickname,
+                    bio = profile.bio,
+                    isVerified = profile.isVerified,
+                    hasStory = state.hasStory,
+                    postsCount = profile.postCount,
+                    followersCount = profile.followerCount,
+                    followingCount = profile.followingCount,
+                    isOwnProfile = state.isOwnProfile && state.viewAsMode == null,
+                    isFollowing = state.isFollowing,
+                    isFollowLoading = state.isFollowLoading,
+                    scrollOffset = scrollProgress,
+                    bioExpanded = bioExpanded,
+                    onToggleBio = { bioExpanded = !bioExpanded },
+                    onProfileImageClick = {
+                         if (state.isOwnProfile) {
+                             onNavigateToEditProfile()
+                         } else if (!profile.avatar.isNullOrBlank()) {
+                             onOpenMediaViewer(listOf(profile.avatar), 0)
+                         }
+                    },
+                    onCoverPhotoClick = {
+                         if (state.isOwnProfile) {
+                             onNavigateToEditProfile()
+                         } else if (!profile.coverImageUrl.isNullOrBlank()) {
+                             onOpenMediaViewer(listOf(profile.coverImageUrl), 0)
+                         }
+                    },
+                    onEditProfileClick = onNavigateToEditProfile,
+                    onFollowClick = {
+                        if (state.isFollowing) {
+                            viewModel.unfollowUser(profile.id)
+                        } else {
+                            viewModel.followUser(profile.id)
+                        }
+                    },
+                    onMessageClick = { onNavigateToChat(profile.id, profile.name ?: profile.username, profile.avatar) },
+                    onAddStoryClick = onNavigateToStoryCreator,
+                    onMoreClick = { viewModel.toggleMoreMenu() },
+                    onStatsClick = { stat ->
+                        when (stat) {
+                            "followers" -> onNavigateToFollowers()
+                            "following" -> onNavigateToFollowing()
+                        }
                     }
-                },
-                onMessageClick = { onNavigateToChat(profile.id, profile.name ?: profile.username, profile.avatar) },
-                onAddStoryClick = onNavigateToStoryCreator,
-                onMoreClick = { viewModel.toggleMoreMenu() },
-                onStatsClick = { stat ->
-                    when (stat) {
-                        "followers" -> onNavigateToFollowers()
-                        "following" -> onNavigateToFollowing()
-                    }
-                }
-            )
-        }
-        item {
-            val prof = (state.profileState as? ProfileUiState.Success)?.profile
-            if (prof != null) {
+                )
+            } else if (isLoading) {
                 Column {
-
-                            Spacer(modifier = Modifier.height(Spacing.Medium))
-                            UserDetailsSection(
-                                details = UserDetails(
-                                    location = prof.location,
-                                    joinedDate = formatJoinedDate(prof.joinedDate),
-                                    relationshipStatus = prof.relationshipStatus,
-                                    birthday = prof.birthday,
-                                    work = prof.work,
-                                    education = prof.education,
-                                    website = prof.website,
-                                    gender = prof.gender,
-                                    pronouns = prof.pronouns,
-                                    linkedAccounts = prof.linkedAccounts.map {
-                                        LinkedAccount(
-                                            platform = it.platform,
-                                            username = it.username
-                                        )
-                                    },
-                                    currentCity = prof.currentCity,
-                                    hometown = prof.hometown,
-                                    occupation = prof.occupation,
-                                    workplace = prof.workplace,
-                                    discordTag = prof.discordTag,
-                                    githubProfile = prof.githubProfile,
-                                    personalWebsite = prof.personalWebsite,
-                                    publicEmail = prof.publicEmail
-                                ),
-                                isOwnProfile = state.isOwnProfile,
-                                onCustomizeClick = onCustomizeClick,
-                                onWebsiteClick = { url ->
-                                     IntentUtils.openUrl(context, url)
-                                 },
-                                modifier = Modifier.padding(horizontal = Spacing.Medium)
-                            )
-
-                            Spacer(modifier = Modifier.height(Spacing.Medium))
-
-                            FollowingSection(
-                                users = state.followingList,
-                                selectedFilter = FollowingFilter.ALL,
-                                onFilterSelected = { },
-                                onUserClick = { user -> onNavigateToUserProfile(user.id) },
-                                onSeeAllClick = onNavigateToFollowing,
-                                modifier = Modifier.padding(horizontal = Spacing.Medium)
-                            )
-
-                            Spacer(modifier = Modifier.height(Spacing.Medium))
+                    ProfileHeaderShimmer()
+                    ProfileBioShimmer(displayName = state.viewAsUserName)
+                    Spacer(modifier = Modifier.height(Spacing.Medium))
+                    ProfileStatsShimmer()
+                    Spacer(modifier = Modifier.height(Spacing.Medium))
+                    ProfileActionsShimmer()
+                    Spacer(modifier = Modifier.height(Spacing.Medium))
                 }
             }
+        }
 
+        item {
+            if (profile != null) {
+                Column {
+                    Spacer(modifier = Modifier.height(Spacing.Medium))
+                    UserDetailsSection(
+                        details = UserDetails(
+                            location = profile.location,
+                            joinedDate = formatJoinedDate(profile.joinedDate),
+                            relationshipStatus = profile.relationshipStatus,
+                            birthday = profile.birthday,
+                            work = profile.work,
+                            education = profile.education,
+                            website = profile.website,
+                            gender = profile.gender,
+                            pronouns = profile.pronouns,
+                            linkedAccounts = profile.linkedAccounts.map {
+                                LinkedAccount(
+                                    platform = it.platform,
+                                    username = it.username
+                                )
+                            },
+                            currentCity = profile.currentCity,
+                            hometown = profile.hometown,
+                            occupation = profile.occupation,
+                            workplace = profile.workplace,
+                            discordTag = profile.discordTag,
+                            githubProfile = profile.githubProfile,
+                            personalWebsite = profile.personalWebsite,
+                            publicEmail = profile.publicEmail
+                        ),
+                        isOwnProfile = state.isOwnProfile,
+                        onCustomizeClick = onCustomizeClick,
+                        onWebsiteClick = { url ->
+                             IntentUtils.openUrl(context, url)
+                         },
+                        modifier = Modifier.padding(horizontal = Spacing.Medium)
+                    )
+
+                    Spacer(modifier = Modifier.height(Spacing.Medium))
+
+                    FollowingSection(
+                        users = state.followingList,
+                        selectedFilter = FollowingFilter.ALL,
+                        onFilterSelected = { },
+                        onUserClick = { user -> onNavigateToUserProfile(user.id) },
+                        onSeeAllClick = onNavigateToFollowing,
+                        modifier = Modifier.padding(horizontal = Spacing.Medium)
+                    )
+
+                    Spacer(modifier = Modifier.height(Spacing.Medium))
+                }
+            } else if (isLoading) {
+                Column {
+                    ProfileDetailsShimmer()
+                    Spacer(modifier = Modifier.height(Spacing.Medium))
+                    FollowingSectionShimmer()
+                    Spacer(modifier = Modifier.height(Spacing.Medium))
+                }
+            }
         }
 
         item {
@@ -247,7 +268,15 @@ internal fun ProfileContent(
                             )
                         } else {
                             val photos = remember(state.photos) {
-                                state.photos.filterIsInstance<MediaItem>()
+                                state.photos.filterIsInstance<DomainMediaItem>().map {
+                                    com.synapse.social.studioasinc.feature.profile.profile.components.MediaItem(
+                                        id = it.id,
+                                        url = it.url,
+                                        isVideo = it.type == MediaType.VIDEO,
+                                        isMultiple = false,
+                                        thumbnailUrl = it.thumbnailUrl
+                                    )
+                                }
                             }
                             PhotoGrid(
                                 items = photos,
@@ -261,14 +290,16 @@ internal fun ProfileContent(
                         }
                     }
                     ProfileContentFilter.POSTS -> {
-                        val prof = (state.profileState as? ProfileUiState.Success)?.profile ?: return@crossfadeContent
-                        Column {
-                            if (state.posts.isEmpty() && !state.isLoadingMore && !state.isRefreshing) {
-                                EmptyState(
-                                    icon = Icons.AutoMirrored.Filled.Article,
-                                    title = if (state.isOwnProfile) stringResource(R.string.empty_own_posts_title) else stringResource(R.string.empty_user_posts_title),
-                                    message = if (state.isOwnProfile) stringResource(R.string.empty_own_posts_msg) else stringResource(R.string.empty_user_posts_msg)
-                                )
+                        val prof = (state.profileState as? ProfileUiState.Success)?.profile
+                        if (prof != null || isLoading) {
+                            Column {
+                                if (state.posts.isEmpty() && !state.isLoadingMore && !state.isRefreshing && !isLoading) {
+                                    EmptyState(
+                                        icon = Icons.AutoMirrored.Filled.Article,
+                                        title = if (state.isOwnProfile) stringResource(R.string.empty_own_posts_title) else stringResource(R.string.empty_user_posts_title),
+                                        message = if (state.isOwnProfile) stringResource(R.string.empty_own_posts_msg) else stringResource(R.string.empty_user_posts_msg)
+                                    )
+                                }
                             }
                         }
                     }
@@ -281,7 +312,15 @@ internal fun ProfileContent(
                             )
                         } else {
                             val reels = remember(state.reels) {
-                                state.reels.filterIsInstance<MediaItem>()
+                                state.reels.filterIsInstance<DomainMediaItem>().map {
+                                    com.synapse.social.studioasinc.feature.profile.profile.components.MediaItem(
+                                        id = it.id,
+                                        url = it.url,
+                                        isVideo = it.type == MediaType.VIDEO,
+                                        isMultiple = false,
+                                        thumbnailUrl = it.thumbnailUrl
+                                    )
+                                }
                             }
                             ReelsGrid(
                                 items = reels,
@@ -302,6 +341,12 @@ internal fun ProfileContent(
                         }
                     }
                 }
+            }
+        }
+
+        if (state.posts.isEmpty() && isLoading && state.contentFilter == ProfileContentFilter.POSTS) {
+            items(3) {
+                PostCardSkeleton(modifier = Modifier.padding(bottom = Spacing.Small))
             }
         }
 

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/ProfileScreen.kt
@@ -141,13 +141,26 @@ fun ProfileScreen(
                 modifier = Modifier.fillMaxSize()
             ) {
             when (val profileState = state.profileState) {
-                is ProfileUiState.Loading -> {
-                    ProfileSkeletonScreen()
+                is ProfileUiState.Error -> {
+                    ErrorState(
+                        title = stringResource(R.string.error_loading_profile),
+                        message = profileState.message,
+                        onRetry = { viewModel.refreshProfile(userId) }
+                    )
                 }
-                is ProfileUiState.Success -> {
+                is ProfileUiState.Empty -> {
+                    EmptyState(
+                        icon = Icons.Default.Person,
+                        title = stringResource(R.string.no_user_data_found),
+                        message = stringResource(R.string.profile_not_found_msg)
+                    )
+                }
+                else -> {
+                    val profile = (profileState as? ProfileUiState.Success)?.profile
                     ProfileContent(
                         state = effectiveState,
-                        profile = profileState.profile,
+                        profile = profile,
+                        isLoading = profileState is ProfileUiState.Loading,
                         listState = listState,
                         scrollProgress = scrollProgress.value,
                         viewModel = viewModel,
@@ -170,27 +183,13 @@ fun ProfileScreen(
                         }
                     )
                 }
-                is ProfileUiState.Error -> {
-                    ErrorState(
-                        title = stringResource(R.string.error_loading_profile),
-                        message = profileState.message,
-                        onRetry = { viewModel.refreshProfile(userId) }
-                    )
-                }
-                is ProfileUiState.Empty -> {
-                    EmptyState(
-                        icon = Icons.Default.Person,
-                        title = stringResource(R.string.no_user_data_found),
-                        message = stringResource(R.string.profile_not_found_msg)
-                    )
-                }
             }
         }
         }
 
         val profile = (state.profileState as? ProfileUiState.Success)?.profile
         ProfileTopAppBar(
-            displayName = profile?.name ?: profile?.username ?: "",
+            displayName = profile?.name ?: profile?.username ?: state.viewAsUserName ?: "",
             scrollProgress = scrollProgress.value,
             onBackClick = onNavigateBack,
             onMoreClick = { viewModel.toggleMoreMenu() }
@@ -263,4 +262,3 @@ fun ProfileScreen(
         )
     }
 }
-

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/components/ProfileSkeleton.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/components/ProfileSkeleton.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 import com.synapse.social.studioasinc.ui.components.ShimmerBox
@@ -14,148 +16,160 @@ import com.synapse.social.studioasinc.ui.components.ShimmerCircle
 import com.synapse.social.studioasinc.feature.shared.theme.Sizes
 
 @Composable
-fun ProfileHeaderSkeleton(modifier: Modifier = Modifier) {
-    Column(
+fun ProfileHeaderShimmer(modifier: Modifier = Modifier) {
+    Box(
         modifier = modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surface)
     ) {
-        Box(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            ShimmerBox(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(Sizes.HeightExtraLarge),
-                shape = RoundedCornerShape(0.dp)
-            )
-
-            Box(
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .padding(start = Spacing.Medium)
-                    .offset(y = Sizes.AvatarHugeHalfOffset) // half of AvatarHuge (110.dp)
-            ) {
-                ShimmerCircle(size = Sizes.AvatarHuge)
-            }
-        }
-
-        Spacer(modifier = Modifier.height(Sizes.AvatarHugeOffset))
-
-        Column(
+        ShimmerBox(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = Spacing.Medium)
+                .height(Sizes.HeightExtraLarge),
+            shape = RoundedCornerShape(0.dp)
+        )
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(start = Spacing.Medium)
+                .offset(y = Sizes.AvatarHugeHalfOffset) // half of AvatarHuge
         ) {
+            ShimmerCircle(size = Sizes.AvatarHuge)
+        }
+    }
+}
+
+@Composable
+fun ProfileBioShimmer(displayName: String? = null, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = Spacing.Medium)
+    ) {
+        Spacer(modifier = Modifier.height(Sizes.AvatarHugeOffset))
+
+        if (displayName != null) {
+            Text(
+                text = displayName,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        } else {
             ShimmerBox(
                 modifier = Modifier
                     .width(Sizes.ShimmerWidthExtraLarge)
                     .height(Sizes.ShimmerTextMedium)
             )
-            Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
+        ShimmerBox(
+            modifier = Modifier
+                .width(Sizes.ShimmerWidthMedium)
+                .height(Spacing.MediumLarge)
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.Small))
+        ShimmerBox(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .height(Sizes.ShimmerTextSmall)
+        )
+        Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
+        ShimmerBox(
+            modifier = Modifier
+                .fillMaxWidth(0.6f)
+                .height(Sizes.ShimmerTextSmall)
+        )
+    }
+}
+
+@Composable
+fun ProfileStatsShimmer(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = Spacing.Medium)
+    ) {
+        ShimmerBox(
+            modifier = Modifier
+                .fillMaxWidth(0.8f)
+                .height(Sizes.ShimmerTextSmall)
+        )
+    }
+}
+
+@Composable
+fun ProfileActionsShimmer(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = Spacing.Medium),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.Small),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        repeat(2) {
             ShimmerBox(
                 modifier = Modifier
-                    .width(Sizes.ShimmerWidthMedium)
-                    .height(Spacing.MediumLarge)
+                    .weight(1f)
+                    .height(Spacing.ButtonHeight),
+                shape = RoundedCornerShape(Sizes.CornerExtraLarge)
             )
+        }
+    }
+}
 
-            Spacer(modifier = Modifier.height(Spacing.Small))
-            ShimmerBox(
-                modifier = Modifier
-                    .fillMaxWidth(0.9f)
-                    .height(Sizes.ShimmerTextSmall)
-            )
-            Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
-            ShimmerBox(
-                modifier = Modifier
-                    .fillMaxWidth(0.6f)
-                    .height(Sizes.ShimmerTextSmall)
-            )
-
-            Spacer(modifier = Modifier.height(Spacing.Medium))
-
-            // Stats Row (InlineStatsText placeholder)
+@Composable
+fun ProfileDetailsShimmer(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = Spacing.Medium)
+    ) {
+        ShimmerBox(
+            modifier = Modifier
+                .width(Sizes.ShimmerWidthMedium)
+                .height(Sizes.ShimmerTextMedium)
+        )
+        Spacer(modifier = Modifier.height(Spacing.Small))
+        repeat(3) {
             ShimmerBox(
                 modifier = Modifier
                     .fillMaxWidth(0.8f)
                     .height(Sizes.ShimmerTextSmall)
             )
+            Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
+        }
+    }
+}
 
-            Spacer(modifier = Modifier.height(Spacing.Medium))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(Spacing.Small),
-                verticalAlignment = Alignment.CenterVertically
+@Composable
+fun FollowingSectionShimmer(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = Spacing.Medium),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.Medium)
+    ) {
+        repeat(4) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                repeat(2) {
-                    ShimmerBox(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(Spacing.Huge),
-                        shape = RoundedCornerShape(Sizes.CornerExtraLarge) // Assuming rounded expressive buttons
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(Spacing.Medium))
-
-            // About / Details Section Placeholder
-            ShimmerBox(
-                modifier = Modifier
-                    .width(Sizes.ShimmerWidthMedium)
-                    .height(Sizes.ShimmerTextMedium)
-            )
-            Spacer(modifier = Modifier.height(Spacing.Small))
-            repeat(3) {
+                ShimmerCircle(size = Sizes.AvatarLarge)
+                Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
                 ShimmerBox(
                     modifier = Modifier
-                        .fillMaxWidth(0.8f)
+                        .width(Sizes.AvatarLarge)
                         .height(Sizes.ShimmerTextSmall)
                 )
-                Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
             }
-
-            Spacer(modifier = Modifier.height(Spacing.Medium))
-
-            // Following Section Placeholder
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(Spacing.Medium)
-            ) {
-                repeat(4) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        ShimmerCircle(size = Sizes.AvatarLarge)
-                        Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
-                        ShimmerBox(
-                            modifier = Modifier
-                                .width(Sizes.AvatarLarge)
-                                .height(Sizes.ShimmerTextSmall)
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(Spacing.Medium))
-
-            // Content Filter Tabs Placeholder
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(Spacing.Small)
-            ) {
-                repeat(4) {
-                    ShimmerBox(
-                        modifier = Modifier
-                            .width(Sizes.WidthLarge)
-                            .height(Sizes.HeightChip),
-                        shape = RoundedCornerShape(Sizes.CornerMassive)
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(Spacing.Medium))
         }
     }
 }
@@ -182,7 +196,6 @@ fun PostCardSkeleton(modifier: Modifier = Modifier) {
             Spacer(modifier = Modifier.width(Spacing.SmallMedium))
 
             Column(modifier = Modifier.weight(1f)) {
-                // Header text placeholder
                 ShimmerBox(
                     modifier = Modifier
                         .width(Sizes.ShimmerWidthLarge)
@@ -197,7 +210,6 @@ fun PostCardSkeleton(modifier: Modifier = Modifier) {
 
                 Spacer(modifier = Modifier.height(Spacing.Small))
 
-                // Content text placeholders
                 ShimmerBox(
                     modifier = Modifier
                         .fillMaxWidth(0.9f)
@@ -212,7 +224,6 @@ fun PostCardSkeleton(modifier: Modifier = Modifier) {
 
                 Spacer(modifier = Modifier.height(Spacing.Small))
 
-                // Media placeholder
                 ShimmerBox(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -221,7 +232,6 @@ fun PostCardSkeleton(modifier: Modifier = Modifier) {
 
                 Spacer(modifier = Modifier.height(Spacing.SmallMedium))
 
-                // Interaction bar placeholder
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween
@@ -236,7 +246,6 @@ fun PostCardSkeleton(modifier: Modifier = Modifier) {
                 }
             }
         }
-
         Spacer(modifier = Modifier.height(Spacing.Small))
     }
 }

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/components/ProfileSkeletonScreen.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/profile/profile/components/ProfileSkeletonScreen.kt
@@ -12,7 +12,8 @@ fun ProfileSkeletonScreen() {
         userScrollEnabled = false
     ) {
         item {
-            ProfileHeaderSkeleton()
+            ProfileHeaderShimmer()
+            ProfileBioShimmer()
         }
         items(3) {
             PostCardSkeleton()


### PR DESCRIPTION
Refactored the ProfileScreen loading state to use a granular, component-based shimmer effect instead of a full-screen skeleton. This involves splitting ProfileSkeleton.kt into specific shimmer components and updating ProfileScreen.kt and ProfileContentSection.kt to maintain the UI structure during loading. Also fixed type mismatches in MediaItem usage.

---
*PR created automatically by Jules for task [12701706147026421220](https://jules.google.com/task/12701706147026421220) started by @TheRealAshik*