### PR TITLE
Fix Camera Permission and Realtime Subscription Race Condition

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/ui/settings/AvatarScreen.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/ui/settings/AvatarScreen.kt
@@ -1,6 +1,9 @@
 package com.synapse.social.studioasinc.ui.settings
 
 import android.widget.Toast
+import android.Manifest
+import androidx.core.content.ContextCompat
+import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -150,6 +153,15 @@ fun AvatarScreen(
             viewModel.uploadBitmap(bitmap)
         }
     }
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            cameraLauncher.launch(null)
+        } else {
+            Toast.makeText(context, context.getString(R.string.camera_permission_required), Toast.LENGTH_SHORT).show()
+        }
+    }
 
     if (showRemoveDialog) {
         AlertDialog(
@@ -244,10 +256,15 @@ fun AvatarScreen(
                         imageVector = Icons.Filled.CameraAlt,
                         position = SettingsItemPosition.Middle,
                         onClick = {
-                            try {
-                                cameraLauncher.launch(null)
-                            } catch (e: android.content.ActivityNotFoundException) {
-                                Toast.makeText(context, context.getString(R.string.no_camera_available), Toast.LENGTH_SHORT).show()
+                            val permissionCheck = ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)
+                            if (permissionCheck == PackageManager.PERMISSION_GRANTED) {
+                                try {
+                                    cameraLauncher.launch(null)
+                                } catch (e: android.content.ActivityNotFoundException) {
+                                    Toast.makeText(context, context.getString(R.string.no_camera_available), Toast.LENGTH_SHORT).show()
+                                }
+                            } else {
+                                cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
                             }
                         }
                     )

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/ChatRealtimeDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/ChatRealtimeDataSource.kt
@@ -67,12 +67,14 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
         }
 
         val collector = launch {
+            kotlinx.coroutines.yield()
             flow.map { it.decodeRecord<MessageDto>() }.collect { message ->
                 trySend(message)
             }
         }
 
         launch(Dispatchers.IO) {
+            kotlinx.coroutines.yield()
             try {
                 Napier.d("Subscribing to channel: \$channelId")
                 channel.subscribe()
@@ -88,6 +90,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
             Napier.d("Closing channel: \$channelId")
             collector.cancel()
             launch {
+            kotlinx.coroutines.yield()
                 try {
                     channel.unsubscribe()
                     client.realtime.removeChannel(channel)
@@ -107,6 +110,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
         }
 
         val collector = launch {
+            kotlinx.coroutines.yield()
             flow.collect { action ->
                 try {
                     val message = action.decodeRecord<MessageDto>()
@@ -118,6 +122,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
         }
 
         launch {
+            kotlinx.coroutines.yield()
             try {
                 Napier.d("Subscribing to channel: \$channelId")
                 channel.subscribe()
@@ -131,6 +136,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
             Napier.d("Closing channel: \$channelId")
             collector.cancel()
             launch {
+            kotlinx.coroutines.yield()
                 try {
                     channel.unsubscribe()
                     client.realtime.removeChannel(channel)
@@ -147,6 +153,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
         val channel = client.realtime.channel(channelId)
 
         val collector = launch {
+            kotlinx.coroutines.yield()
             channel.presenceChangeFlow().collect { presenceChange ->
                 presenceChange.joins.values.forEach { presence ->
                     try {
@@ -178,6 +185,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
         }
 
         launch(Dispatchers.IO) {
+            kotlinx.coroutines.yield()
             try {
                 Napier.d("Subscribing to channel: \$channelId")
                 channel.subscribe()
@@ -193,6 +201,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
             Napier.d("Closing channel: \$channelId")
             collector.cancel()
             launch {
+            kotlinx.coroutines.yield()
                 try {
                     channel.unsubscribe()
                     client.realtime.removeChannel(channel)
@@ -213,12 +222,14 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
         }
 
         val collector = launch {
+            kotlinx.coroutines.yield()
             flow.map { it.decodeRecord<MessageDto>() }.collect { message ->
                 trySend(message)
             }
         }
 
         launch(Dispatchers.IO) {
+            kotlinx.coroutines.yield()
             try {
                 Napier.d("Subscribing to channel: \$channelId")
                 channel.subscribe()
@@ -234,6 +245,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
             Napier.d("Closing channel: \$channelId")
             collector.cancel()
             launch {
+            kotlinx.coroutines.yield()
                 try {
                     channel.unsubscribe()
                     client.realtime.removeChannel(channel)
@@ -252,6 +264,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
         }
 
         val collector = launch {
+            kotlinx.coroutines.yield()
             flow.collect { action ->
                 when (action) {
                     is PostgresAction.Insert -> try { trySend(action.decodeRecord<MessageReactionDto>()) } catch(e: Exception) {}
@@ -263,6 +276,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
         }
 
         launch {
+            kotlinx.coroutines.yield()
             try {
                 channel.subscribe()
             } catch (e: Exception) {
@@ -273,6 +287,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
         awaitClose {
             collector.cancel()
             launch {
+            kotlinx.coroutines.yield()
                 channel.unsubscribe()
                 client.realtime.removeChannel(channel)
             }


### PR DESCRIPTION
This PR addresses two critical issues:
1. A SecurityException occurring when the user tries to take a photo for their avatar without having granted camera permissions. We now explicitly check and request the CAMERA permission at runtime.
2. An IllegalStateException in the Supabase Realtime subscription logic within ChatRealtimeDataSource. This was caused by a race condition where the channel was joined before the postgresChangeFlow was established. Using yield() ensures the correct ordering of these operations.

---
*PR created automatically by Jules for task [4858472811035652903](https://jules.google.com/task/4858472811035652903) started by @TheRealAshik*