### PR TITLE
Fix E2EE permanent decryption failures caused by unilateral session deletion

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
@@ -309,6 +309,16 @@ class ChatViewModel @Inject constructor(
         initializationDelegate.initialize(chatId, participantId, currentChatId)
     }
 
+    /** Re-fetches messages for the current chat (e.g. after screen resumes from off). */
+    fun refreshMessages() {
+        val chatId = currentChatId ?: return
+        viewModelScope.launch {
+            getMessagesUseCase(chatId).onSuccess { messages ->
+                messagingDelegate.setMessages(messages)
+            }
+        }
+    }
+
     private fun handleIncomingMessage(newMessage: Message) {
         val encryptedPlaceholders = ChatMessagingDelegate.ENCRYPTED_PLACEHOLDERS
         messagingDelegate._messages.update { current ->

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
@@ -164,6 +164,18 @@ fun ChatScreen(
         viewModel.initialize(chatId, participantId)
     }
 
+    // Re-fetch messages when screen resumes (catches messages missed while screen was off)
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshMessages()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     val messages by viewModel.messages.collectAsState()
     val chatItems by viewModel.chatItems.collectAsState()
     val inputText by viewModel.inputText.collectAsState()

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/ChatEncryptionHelper.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/ChatEncryptionHelper.kt
@@ -92,9 +92,7 @@ internal class ChatEncryptionHelper(
                     try { cachedMessageDao?.updateContent(messageId, content) } catch (_: Exception) {}
                     return this.copy(content = content, mediaUrl = mediaUrl ?: this.mediaUrl)
                 } catch (decryptError: Exception) {
-                    Logger.e("E2EE_DECRYPT: Signal decryption failed for message $messageId. Deleting session to force recovery.", tag = "E2EE", throwable = decryptError)
-                    signalProtocolManager.deleteSession(senderId)
-                    signalProtocolManager.deleteIdentity(senderId)
+                    Logger.e("E2EE_DECRYPT: Signal decryption failed for message $messageId.", tag = "E2EE", throwable = decryptError)
 
                     // Return placeholder instead of leaking raw encrypted JSON on failure
                     val fallbackContent = if (this.senderId == currentUserId) "🔒 You sent an encrypted message" else "🔒 Encrypted message"


### PR DESCRIPTION
Previously, any transient decryption error (like out-of-order delivery or duplicates) caused the recipient to unilaterally delete the sender's Signal session and identity. Because the sender was unaware of this deletion, they continued encrypting with the broken session, rendering all subsequent messages permanently unreadable ("Encrypted message"). 

Removing this aggressive deletion allows the Signal Protocol to properly handle occasional errors and recover state through ratcheting without permanently severing trust between devices.

---
*PR created automatically by Jules for task [6364004333275025030](https://jules.google.com/task/6364004333275025030) started by @TheRealAshik*