### PR TITLE
🐛 fix: Refactor comments to X-style threaded posts

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/data/local/database/SettingsDataStore.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/local/database/SettingsDataStore.kt
@@ -71,6 +71,7 @@ class SettingsDataStore private constructor(
             preferences.remove(SettingsConstants.KEY_CHAT_FOLDERS)
             preferences.remove(SettingsConstants.KEY_CHAT_MAX_MESSAGE_CHUNK_SIZE)
             preferences.remove(SettingsConstants.KEY_MESSAGE_SUGGESTION_ENABLED)
+            preferences.remove(SettingsConstants.KEY_CHAT_AVATAR_DISABLED)
 
             preferences.remove(SettingsConstants.KEY_DATA_SAVER_ENABLED)
 
@@ -126,6 +127,7 @@ class SettingsDataStore private constructor(
             preferences.remove(SettingsConstants.KEY_CHAT_FOLDERS)
             preferences[SettingsConstants.KEY_CHAT_MAX_MESSAGE_CHUNK_SIZE] = SettingsConstants.DEFAULT_CHAT_MAX_MESSAGE_CHUNK_SIZE
             preferences[SettingsConstants.KEY_MESSAGE_SUGGESTION_ENABLED] = SettingsConstants.DEFAULT_MESSAGE_SUGGESTION_ENABLED
+            preferences[SettingsConstants.KEY_CHAT_AVATAR_DISABLED] = SettingsConstants.DEFAULT_CHAT_AVATAR_DISABLED
 
             preferences[SettingsConstants.KEY_DATA_SAVER_ENABLED] = SettingsConstants.DEFAULT_DATA_SAVER_ENABLED
 

--- a/app/src/main/java/com/synapse/social/studioasinc/data/local/database/settings/ChatStore.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/local/database/settings/ChatStore.kt
@@ -19,6 +19,7 @@ interface ChatStore {
     val chatSwipeGesture: Flow<com.synapse.social.studioasinc.shared.domain.model.settings.ChatSwipeGesture>
     val chatMaxMessageChunkSize: Flow<Int>
     val chatFoldersJson: Flow<String?>
+    val chatAvatarDisabled: Flow<Boolean>
 
     suspend fun setChatFontScale(scale: Float)
     suspend fun setChatThemePreset(preset: ChatThemePreset)
@@ -30,6 +31,7 @@ interface ChatStore {
     suspend fun setChatSwipeGesture(gesture: com.synapse.social.studioasinc.shared.domain.model.settings.ChatSwipeGesture)
     suspend fun setChatMaxMessageChunkSize(size: Int)
     suspend fun setChatFoldersJson(json: String)
+    suspend fun setChatAvatarDisabled(enabled: Boolean)
 }
 
 class ChatStoreImpl(private val dataStore: DataStore<Preferences>) : ChatStore {
@@ -143,6 +145,16 @@ class ChatStoreImpl(private val dataStore: DataStore<Preferences>) : ChatStore {
     override suspend fun setChatFoldersJson(json: String) {
         dataStore.edit { preferences ->
             preferences[SettingsConstants.KEY_CHAT_FOLDERS] = json
+        }
+    }
+
+    override val chatAvatarDisabled: Flow<Boolean> = dataStore.safePreferencesFlow().map { preferences ->
+        preferences[SettingsConstants.KEY_CHAT_AVATAR_DISABLED] ?: SettingsConstants.DEFAULT_CHAT_AVATAR_DISABLED
+    }
+
+    override suspend fun setChatAvatarDisabled(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[SettingsConstants.KEY_CHAT_AVATAR_DISABLED] = enabled
         }
     }
 }

--- a/app/src/main/java/com/synapse/social/studioasinc/data/local/database/settings/SettingsConstants.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/local/database/settings/SettingsConstants.kt
@@ -61,6 +61,7 @@ object SettingsConstants {
     val KEY_AI_FALLBACK_TO_PLATFORM = booleanPreferencesKey("ai_fallback_to_platform")
     val KEY_AI_CUSTOM_MODEL = stringPreferencesKey("ai_custom_model")
     val KEY_MESSAGE_SUGGESTION_ENABLED = booleanPreferencesKey("message_suggestion_enabled")
+    val KEY_CHAT_AVATAR_DISABLED = booleanPreferencesKey("chat_avatar_disabled")
 
     val KEY_DATA_SAVER_ENABLED = booleanPreferencesKey("data_saver_enabled")
 
@@ -110,6 +111,7 @@ object SettingsConstants {
     val DEFAULT_CHAT_SWIPE_GESTURE = com.synapse.social.studioasinc.shared.domain.model.settings.ChatSwipeGesture.ARCHIVE
     val DEFAULT_CHAT_MAX_MESSAGE_CHUNK_SIZE = 500
     val DEFAULT_MESSAGE_SUGGESTION_ENABLED = false
+    val DEFAULT_CHAT_AVATAR_DISABLED = false
     val DEFAULT_DATA_SAVER_ENABLED = false
     val DEFAULT_ENTER_IS_SEND_ENABLED = false
     val DEFAULT_MEDIA_VISIBILITY_ENABLED = true

--- a/app/src/main/java/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
@@ -103,7 +103,7 @@ class FeedPagingSource(
                             columns = Columns.raw("""
                                 *,
                                 users!author_uid(username, display_name, avatar, verify),
-                                latest_comments:comments(id, content, user_id, created_at, users(username)),
+                                latest_comments:posts!in_reply_to_post_id(id, post_text, author_uid, created_at, users!author_uid(username)),
                                 quoted_post:posts!quoted_post_id(*, users!author_uid(username, display_name, avatar, verify))
                             """.trimIndent())
                         ) {
@@ -127,7 +127,7 @@ class FeedPagingSource(
                                 .maxByOrNull { it["created_at"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull ?: "" }
 
                             if (latestComment != null) {
-                                post.latestCommentText = latestComment["content"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
+                                post.latestCommentText = latestComment["post_text"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
                                 val commentUser = latestComment["users"]?.jsonObject
                                 post.latestCommentAuthor = commentUser?.get("username")?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
                             }

--- a/app/src/main/java/com/synapse/social/studioasinc/data/repository/ReactionRepositoryImpl.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/repository/ReactionRepositoryImpl.kt
@@ -107,7 +107,6 @@ class ReactionRepositoryImpl @Inject constructor(
                             client.from(tableName)
                                 .update({
                                     set("reaction_type", reactionType.name.lowercase())
-                                    set("updated_at", java.time.Instant.now().toString())
                                 }) { filter { eq(idColumn, targetId); eq("user_id", userId) } }
                             Log.d(TAG, "Reaction updated to ${reactionType.name} for $targetType $targetId")
                             ReactionToggleResult.UPDATED
@@ -395,86 +394,42 @@ class ReactionRepositoryImpl @Inject constructor(
 
     suspend fun populateCommentReactions(comments: List<CommentWithUser>): List<CommentWithUser> = withContext(Dispatchers.IO) {
         if (comments.isEmpty()) return@withContext comments
-
+        // Comments are now posts — use the reactions table with post_id
         try {
-            val allCommentIds = comments.map { it.id }
+            val commentIds = comments.map { it.id }
+            val currentUser = client.auth.currentUserOrNull()
             val semaphore = Semaphore(5)
 
             val summaries = supervisorScope {
-                 allCommentIds.chunked(20).map { chunkIds ->
-                     async {
-                         semaphore.withPermit {
-                             try {
-                                 val rpcSummaries = client.postgrest.rpc(
-                                    "get_comments_reactions_summary",
-                                    buildJsonObject {
-                                        put("comment_ids", buildJsonArray {
-                                            chunkIds.forEach { add(it) }
-                                        })
-                                    }
-                                 ).decodeList<CommentReactionSummary>()
+                commentIds.chunked(20).map { chunkIds ->
+                    async {
+                        semaphore.withPermit {
+                            val reactions = client.from("reactions")
+                                .select(io.github.jan.supabase.postgrest.query.Columns.raw("post_id, user_id, reaction_type")) {
+                                    filter { isIn("post_id", chunkIds) }
+                                }
+                                .decodeList<JsonObject>()
 
-                                 val currentUser = client.auth.currentUserOrNull()
-                                 if (currentUser != null) {
-                                     val userReactions = client.from("comment_reactions")
-                                         .select(io.github.jan.supabase.postgrest.query.Columns.raw("comment_id, reaction_type")) {
-                                             filter {
-                                                 isIn("comment_id", chunkIds)
-                                                 eq("user_id", currentUser.id)
-                                             }
-                                         }.decodeList<JsonObject>()
+                            val byId = reactions.groupBy { it["post_id"]?.jsonPrimitive?.contentOrNull }
 
-                                     val userReactionMap = userReactions.associate {
-                                         it["comment_id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull to it.getStringOrNull("reaction_type")
-                                     }
-
-                                     rpcSummaries.map { summary ->
-                                         val userReaction = userReactionMap[summary.commentId]
-                                         if (userReaction != null) {
-                                             summary.copy(userReaction = userReaction)
-                                         } else {
-                                             summary
-                                         }
-                                     }
-                                 } else {
-                                     rpcSummaries
-                                 }
-                             } catch(e: Exception) {
-                                 Log.e(TAG, "Failed to fetch reaction summaries for comment chunk via RPC, falling back", e)
-                                 val reactions = client.from("comment_reactions")
-                                     .select { filter { isIn("comment_id", chunkIds) } }
-                                     .decodeList<JsonObject>()
-
-                                 val currentUser = client.auth.currentUserOrNull()
-
-                                 val reactionsByCommentId = reactions.groupBy { it["comment_id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull }
-
-                                 chunkIds.map { commentId ->
-                                     val commentReactions = reactionsByCommentId[commentId] ?: emptyList()
-                                     val summary = commentReactions
-                                         .groupBy { ReactionType.fromString(it.getStringOrNull("reaction_type") ?: "LIKE") }
-                                         .mapValues { it.value.size }
-                                         .mapKeys { it.key.name.lowercase() }
-
-                                     val userReaction = currentUser?.let { user ->
-                                         commentReactions.firstOrNull { it.getStringOrNull("user_id") == user.id }
-                                             ?.getStringOrNull("reaction_type")
-                                     }
-
-                                     CommentReactionSummary(
-                                         commentId = commentId,
-                                         reactionCounts = summary,
-                                         userReaction = userReaction
-                                     )
-                                 }
-                             }
-                         }
-                     }
-                 }.awaitAll().flatten()
+                            chunkIds.map { commentId ->
+                                val commentReactions = byId[commentId] ?: emptyList()
+                                val summary = commentReactions
+                                    .groupBy { ReactionType.fromString(it.getStringOrNull("reaction_type") ?: "LIKE") }
+                                    .mapValues { it.value.size }
+                                    .mapKeys { it.key.name.lowercase() }
+                                val userReaction = currentUser?.let { user ->
+                                    commentReactions.firstOrNull { it.getStringOrNull("user_id") == user.id }
+                                        ?.getStringOrNull("reaction_type")
+                                }
+                                CommentReactionSummary(commentId = commentId, reactionCounts = summary, userReaction = userReaction)
+                            }
+                        }
+                    }
+                }.awaitAll().flatten()
             }
 
             applyCommentReactionSummaries(comments, summaries)
-
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -581,18 +536,16 @@ suspend fun togglePostReaction(postId: String, reactionType: ReactionType, oldRe
 
     private fun getTableName(targetType: String): String {
         return when (targetType.lowercase()) {
-            "post" -> "reactions"
+            "post", "comment" -> "reactions"
             "message" -> "message_reactions"
-            "comment" -> "comment_reactions"
             else -> "reactions"
         }
     }
 
     private fun getIdColumn(targetType: String): String {
         return when (targetType.lowercase()) {
-            "post" -> "post_id"
+            "post", "comment" -> "post_id"
             "message" -> "message_id"
-            "comment" -> "comment_id"
             else -> "post_id"
         }
     }

--- a/app/src/main/java/com/synapse/social/studioasinc/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/repository/SettingsRepository.kt
@@ -157,6 +157,9 @@ interface SettingsRepository {
     val messageSuggestionEnabled: Flow<Boolean>
     suspend fun setMessageSuggestionEnabled(enabled: Boolean)
 
+    val chatAvatarDisabled: Flow<Boolean>
+    suspend fun setChatAvatarDisabled(enabled: Boolean)
+
     val chatMaxMessageChunkSize: Flow<Int>
     suspend fun setChatMaxMessageChunkSize(size: Int)
 

--- a/app/src/main/java/com/synapse/social/studioasinc/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/repository/SettingsRepositoryImpl.kt
@@ -206,6 +206,12 @@ class SettingsRepositoryImpl private constructor(
         settingsDataStore.setMessageSuggestionEnabled(enabled)
     }
 
+    override val chatAvatarDisabled: Flow<Boolean> = settingsDataStore.chatAvatarDisabled
+
+    override suspend fun setChatAvatarDisabled(enabled: Boolean) {
+        settingsDataStore.setChatAvatarDisabled(enabled)
+    }
+
     override val chatMaxMessageChunkSize: Flow<Int> = settingsDataStore.chatMaxMessageChunkSize
 
     override suspend fun setChatMaxMessageChunkSize(size: Int) {

--- a/app/src/main/java/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
@@ -89,7 +89,7 @@ class CommentRemoteDataSource @Inject constructor(
             .select(Columns.raw(POST_COLUMNS)) {
                 filter {
                     eq("author_uid", userId)
-                    filter("in_reply_to_post_id", io.github.jan.supabase.postgrest.query.filter.FilterOperator.IS_NOT, "null")
+                    filterNot("in_reply_to_post_id", io.github.jan.supabase.postgrest.query.filter.FilterOperator.IS, "null")
                     eq("is_deleted", false)
                 }
                 order("created_at", Order.DESCENDING)

--- a/app/src/main/java/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
@@ -89,7 +89,7 @@ class CommentRemoteDataSource @Inject constructor(
             .select(Columns.raw(POST_COLUMNS)) {
                 filter {
                     eq("author_uid", userId)
-                    not { filter("in_reply_to_post_id", io.github.jan.supabase.postgrest.query.filter.FilterOperator.IS, "null") }
+                    filter("in_reply_to_post_id", io.github.jan.supabase.postgrest.query.filter.FilterOperator.IS_NOT, "null")
                     eq("is_deleted", false)
                 }
                 order("created_at", Order.DESCENDING)

--- a/app/src/main/java/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
@@ -7,101 +7,96 @@ import com.synapse.social.studioasinc.domain.model.UserStatus
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.postgrest.from
-import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.postgrest.query.Columns
 import io.github.jan.supabase.postgrest.query.Order
-import io.github.jan.supabase.postgrest.rpc
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.*
 import javax.inject.Inject
 
+/**
+ * X-style threaded posts: "comments" are posts with in_reply_to_post_id set.
+ * - Top-level replies to a post: in_reply_to_post_id = postId
+ * - Nested replies to a comment: in_reply_to_post_id = commentId
+ * - root_post_id always points to the original root post of the thread.
+ */
 class CommentRemoteDataSource @Inject constructor(
     private val client: SupabaseClient
 ) {
     companion object {
         private const val TAG = "CommentRemoteDataSource"
+        private const val POST_COLUMNS = """
+            id, author_uid, post_text, post_image, media_items,
+            in_reply_to_post_id, root_post_id,
+            likes_count, comments_count, views_count,
+            is_deleted, is_edited, edited_at, created_at, updated_at,
+            users!posts_author_uid_fkey(uid, username, display_name, email, bio, avatar, followers_count, following_count, posts_count, status, account_type, verify, banned)
+        """
     }
 
     suspend fun fetchComments(postId: String, limit: Int, offset: Int): List<CommentWithUser> = withContext(Dispatchers.IO) {
-        val response = client.from("comments")
-            .select(columns = Columns.raw("*, users(uid, username, display_name, avatar, bio, verify, status, account_type, followers_count, following_count, posts_count, banned)")) {
+        client.from("posts")
+            .select(Columns.raw(POST_COLUMNS)) {
                 filter {
-                    eq("post_id", postId)
-                    filterNot("is_deleted", io.github.jan.supabase.postgrest.query.filter.FilterOperator.EQ, true)
-                    // Only fetch top-level comments
-                    filter("parent_comment_id", io.github.jan.supabase.postgrest.query.filter.FilterOperator.IS, "null")
+                    eq("in_reply_to_post_id", postId)
+                    eq("is_deleted", false)
                 }
                 order("created_at", Order.DESCENDING)
                 range(offset.toLong(), (offset + limit - 1).toLong())
             }
-
-        response.decodeList<JsonObject>().mapNotNull { parseCommentFromJson(it) }
+            .decodeList<JsonObject>()
+            .mapNotNull { parsePostAsComment(it) }
     }
 
     suspend fun getComment(commentId: String): CommentWithUser? = withContext(Dispatchers.IO) {
-        val response = client.from("comments")
-            .select(
-                columns = Columns.raw("""
-                    *,
-                    users!comments_user_id_fkey(uid, username, display_name, email, bio, avatar, followers_count, following_count, posts_count, status, account_type, verify, banned)
-                """.trimIndent())
-            ) {
+        client.from("posts")
+            .select(Columns.raw(POST_COLUMNS)) {
                 filter { eq("id", commentId) }
             }
             .decodeSingleOrNull<JsonObject>()
-
-        response?.let { parseCommentFromJson(it) }
+            ?.let { parsePostAsComment(it) }
     }
 
     suspend fun fetchReplies(parentCommentId: String, limit: Int, offset: Int, ascending: Boolean = true): List<CommentWithUser> = withContext(Dispatchers.IO) {
-        val response = client.from("comments")
-            .select(
-                columns = Columns.raw("""
-                    *,
-                    users!comments_user_id_fkey(uid, username, display_name, email, bio, avatar, followers_count, following_count, posts_count, status, account_type, verify, banned)
-                """.trimIndent())
-            ) {
+        client.from("posts")
+            .select(Columns.raw(POST_COLUMNS)) {
                 filter {
-                    eq("parent_comment_id", parentCommentId)
-                    filterNot("is_deleted", io.github.jan.supabase.postgrest.query.filter.FilterOperator.EQ, true)
+                    eq("in_reply_to_post_id", parentCommentId)
+                    eq("is_deleted", false)
                 }
                 order("created_at", if (ascending) Order.ASCENDING else Order.DESCENDING)
                 range(offset.toLong(), (offset + limit - 1).toLong())
             }
             .decodeList<JsonObject>()
-
-        response.mapNotNull { parseCommentFromJson(it) }
+            .mapNotNull { parsePostAsComment(it) }
     }
 
     suspend fun fetchAllReplies(parentCommentId: String): List<CommentWithUser> = withContext(Dispatchers.IO) {
-        val response = client.from("comments")
-            .select(
-                columns = Columns.raw("""
-                    *,
-                    users!comments_user_id_fkey(uid, username, display_name, email, bio, avatar, followers_count, following_count, posts_count, status, account_type, verify, banned)
-                """.trimIndent())
-            ) {
-                filter { eq("parent_comment_id", parentCommentId) }
+        client.from("posts")
+            .select(Columns.raw(POST_COLUMNS)) {
+                filter {
+                    eq("in_reply_to_post_id", parentCommentId)
+                    eq("is_deleted", false)
+                }
                 order("created_at", Order.ASCENDING)
             }
             .decodeList<JsonObject>()
-
-        response.mapNotNull { parseCommentFromJson(it) }
+            .mapNotNull { parsePostAsComment(it) }
     }
 
     suspend fun fetchUserComments(userId: String, limit: Int, offset: Int): List<CommentWithUser> = withContext(Dispatchers.IO) {
-        val response = client.from("comments")
-            .select(columns = Columns.raw("*, users(uid, username, display_name, avatar, bio, verify, status, account_type, followers_count, following_count, posts_count, banned)")) {
+        client.from("posts")
+            .select(Columns.raw(POST_COLUMNS)) {
                 filter {
-                    eq("user_id", userId)
-                    filterNot("is_deleted", io.github.jan.supabase.postgrest.query.filter.FilterOperator.EQ, true)
+                    eq("author_uid", userId)
+                    not { filter("in_reply_to_post_id", io.github.jan.supabase.postgrest.query.filter.FilterOperator.IS, "null") }
+                    eq("is_deleted", false)
                 }
                 order("created_at", Order.DESCENDING)
                 range(offset.toLong(), (offset + limit - 1).toLong())
             }
-
-        response.decodeList<JsonObject>().mapNotNull { parseCommentFromJson(it) }
+            .decodeList<JsonObject>()
+            .mapNotNull { parsePostAsComment(it) }
     }
 
     suspend fun addComment(
@@ -112,75 +107,72 @@ class CommentRemoteDataSource @Inject constructor(
         mediaUrl: String?,
         parentCommentId: String?
     ): CommentWithUser? = withContext(Dispatchers.IO) {
+        // In X-style threading: root_post_id is always the original post,
+        // in_reply_to_post_id is the direct parent (post or comment).
+        val rootPostId = if (parentCommentId != null) {
+            // Fetch parent's root_post_id to propagate the thread root
+            getComment(parentCommentId)?.postId ?: postId
+        } else {
+            postId
+        }
+
         val insertData = buildJsonObject {
             put("id", id)
-            put("post_id", postId)
-            put("user_id", userId)
-            put("content", content)
-            if (mediaUrl != null) put("media_url", mediaUrl)
-            if (parentCommentId != null) put("parent_comment_id", parentCommentId)
+            put("author_uid", userId)
+            put("post_text", content)
+            if (mediaUrl != null) put("post_image", mediaUrl)
+            put("in_reply_to_post_id", parentCommentId ?: postId)
+            put("root_post_id", rootPostId)
+            put("post_type", "TEXT")
             put("created_at", java.time.Instant.now().toString())
             put("updated_at", java.time.Instant.now().toString())
         }
 
-        val response = client.from("comments")
+        client.from("posts")
             .insert(insertData) {
-                select(
-                    columns = Columns.raw("""
-                        *,
-                        users!comments_user_id_fkey(uid, username, display_name, email, bio, avatar, followers_count, following_count, posts_count, status, account_type, verify, banned)
-                    """.trimIndent())
-                )
+                select(Columns.raw(POST_COLUMNS))
             }
             .decodeSingleOrNull<JsonObject>()
-
-        response?.let { parseCommentFromJson(it) }
+            ?.let { parsePostAsComment(it) }
     }
 
     suspend fun updateComment(commentId: String, newContent: String): CommentWithUser? = withContext(Dispatchers.IO) {
-        val response = client.from("comments")
+        client.from("posts")
             .update({
-                set("content", newContent)
+                set("post_text", newContent)
                 set("is_edited", true)
                 set("edited_at", java.time.Instant.now().toString())
+                set("updated_at", java.time.Instant.now().toString())
             }) {
                 filter { eq("id", commentId) }
-                select(Columns.raw("*, users(uid, username, display_name, avatar, verify)"))
+                select(Columns.raw(POST_COLUMNS))
             }
             .decodeSingleOrNull<JsonObject>()
-
-        response?.let { parseCommentFromJson(it) }
+            ?.let { parsePostAsComment(it) }
     }
 
     suspend fun markCommentDeleted(commentId: String) = withContext(Dispatchers.IO) {
-        client.from("comments")
-            .update({ set("is_deleted", true) }) {
-                filter { eq("id", commentId) }
-            }
-    }
-
-    suspend fun pinComment(commentId: String) = withContext(Dispatchers.IO) {
-        client.from("comments")
-            .update({ set("is_pinned", true) }) {
-                filter { eq("id", commentId) }
-            }
-    }
-
-    suspend fun hideComment(commentId: String, currentUserId: String) = withContext(Dispatchers.IO) {
-        client.from("comments")
+        client.from("posts")
             .update({
-                set("is_hidden", true)
-                set("hidden_by", currentUserId)
+                set("is_deleted", true)
+                set("deleted_at", java.time.Instant.now().toString())
             }) {
                 filter { eq("id", commentId) }
             }
     }
 
+    /** Posts don't have is_pinned — no-op for now. */
+    suspend fun pinComment(commentId: String) = Unit
+
+    /** Posts don't have is_hidden — no-op for now. */
+    suspend fun hideComment(commentId: String, currentUserId: String) = Unit
+
     suspend fun reportComment(commentId: String, reporterId: String, reason: String) = withContext(Dispatchers.IO) {
-        client.from("comment_reports")
+        client.from("reports")
             .insert(buildJsonObject {
-                put("comment_id", commentId)
                 put("reporter_id", reporterId)
+                put("target_id", commentId)
+                put("target_type", "comment")
                 put("reason", reason)
                 put("created_at", java.time.Instant.now().toString())
             })
@@ -188,10 +180,14 @@ class CommentRemoteDataSource @Inject constructor(
 
     suspend fun updateRepliesCount(commentId: String, delta: Int) = withContext(Dispatchers.IO) {
         try {
-            client.postgrest.rpc(
-                "increment_replies_count",
-                mapOf("comment_id" to commentId, "delta" to delta)
-            )
+            val post = client.from("posts")
+                .select(Columns.raw("id, comments_count")) { filter { eq("id", commentId) } }
+                .decodeSingleOrNull<JsonObject>()
+            val current = post?.get("comments_count")?.jsonPrimitive?.intOrNull ?: 0
+            client.from("posts")
+                .update({ set("comments_count", maxOf(0, current + delta)) }) {
+                    filter { eq("id", commentId) }
+                }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to update replies count: ${e.message}")
         }
@@ -200,14 +196,11 @@ class CommentRemoteDataSource @Inject constructor(
     suspend fun updatePostCommentsCount(postId: String, delta: Int) = withContext(Dispatchers.IO) {
         try {
             val post = client.from("posts")
-                .select { filter { eq("id", postId) } }
+                .select(Columns.raw("id, comments_count")) { filter { eq("id", postId) } }
                 .decodeSingleOrNull<JsonObject>()
-
-            val currentCount = post?.get("comments_count")?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.intOrNull ?: 0
-            val newCount = maxOf(0, currentCount + delta)
-
+            val current = post?.get("comments_count")?.jsonPrimitive?.intOrNull ?: 0
             client.from("posts")
-                .update({ set("comments_count", newCount) }) {
+                .update({ set("comments_count", maxOf(0, current + delta)) }) {
                     filter { eq("id", postId) }
                 }
         } catch (e: Exception) {
@@ -216,71 +209,75 @@ class CommentRemoteDataSource @Inject constructor(
     }
 
     suspend fun getPostAuthorId(postId: String): String? = withContext(Dispatchers.IO) {
-        val post = client.from("posts")
-            .select { filter { eq("id", postId) } }
+        client.from("posts")
+            .select(Columns.raw("author_uid")) { filter { eq("id", postId) } }
             .decodeSingleOrNull<JsonObject>()
-        post?.get("author_uid")?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
+            ?.get("author_uid")?.jsonPrimitive?.contentOrNull
     }
 
     suspend fun getCurrentUser() = withContext(Dispatchers.IO) {
         client.auth.currentUserOrNull()
     }
 
-    private fun parseCommentFromJson(data: JsonObject): CommentWithUser? {
+    private fun parsePostAsComment(data: JsonObject): CommentWithUser? {
         return try {
-            val user = parseUserProfileFromJson(data["users"]?.jsonObject)
-            val commentId = data["id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull ?: return null
+            val id = data["id"]?.jsonPrimitive?.contentOrNull ?: return null
+            val authorUid = data["author_uid"]?.jsonPrimitive?.contentOrNull ?: return null
+            // postId = root_post_id (the thread root), falls back to in_reply_to_post_id
+            val postId = data["root_post_id"]?.jsonPrimitive?.contentOrNull
+                ?: data["in_reply_to_post_id"]?.jsonPrimitive?.contentOrNull
+                ?: return null
+            val parentCommentId = data["in_reply_to_post_id"]?.jsonPrimitive?.contentOrNull
 
             CommentWithUser(
-                id = commentId,
-                postId = data["post_id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull ?: return null,
-                userId = data["user_id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull ?: return null,
-                parentCommentId = data["parent_comment_id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull,
-                content = data["content"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull ?: "",
-                mediaUrl = data["media_url"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull,
-                createdAt = data["created_at"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull ?: "",
-                updatedAt = data["updated_at"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull,
-                likesCount = data["likes_count"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.intOrNull ?: 0,
-                repliesCount = data["replies_count"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.intOrNull ?: 0,
-                isDeleted = data["is_deleted"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.booleanOrNull ?: false,
-                isEdited = data["is_edited"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.booleanOrNull ?: false,
-                isPinned = data["is_pinned"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.booleanOrNull ?: false,
-                user = user,
+                id = id,
+                postId = postId,
+                userId = authorUid,
+                parentCommentId = if (parentCommentId != postId) parentCommentId else null,
+                content = data["post_text"]?.jsonPrimitive?.contentOrNull ?: "",
+                mediaUrl = data["post_image"]?.jsonPrimitive?.contentOrNull,
+                createdAt = data["created_at"]?.jsonPrimitive?.contentOrNull ?: "",
+                updatedAt = data["updated_at"]?.jsonPrimitive?.contentOrNull,
+                likesCount = data["likes_count"]?.jsonPrimitive?.intOrNull ?: 0,
+                repliesCount = data["comments_count"]?.jsonPrimitive?.intOrNull ?: 0,
+                isDeleted = data["is_deleted"]?.jsonPrimitive?.booleanOrNull ?: false,
+                isEdited = data["is_edited"]?.jsonPrimitive?.booleanOrNull ?: false,
+                isPinned = false,
+                user = parseUserFromJson(data["users"]?.jsonObject),
                 reactionSummary = emptyMap(),
                 userReaction = null
             )
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to parse comment: ${e.message}")
+            Log.e(TAG, "Failed to parse post as comment: ${e.message}")
             null
         }
     }
 
-    private fun parseUserProfileFromJson(userData: JsonObject?): UserProfile? {
+    private fun parseUserFromJson(userData: JsonObject?): UserProfile? {
         if (userData == null) return null
-
         return try {
-            val avatarPath = userData["avatar"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
-            val avatarUrl = avatarPath?.let { path ->
-                if (path.startsWith("http")) path else com.synapse.social.studioasinc.shared.core.network.SupabaseClient.constructAvatarUrl(path)
+            val avatarPath = userData["avatar"]?.jsonPrimitive?.contentOrNull
+            val avatarUrl = avatarPath?.let {
+                if (it.startsWith("http")) it
+                else com.synapse.social.studioasinc.shared.core.network.SupabaseClient.constructAvatarUrl(it)
             }
-
             UserProfile(
-                uid = userData["uid"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull ?: return null,
-                username = userData["username"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull ?: "",
-                displayName = userData["display_name"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull ?: "",
+                uid = userData["uid"]?.jsonPrimitive?.contentOrNull ?: return null,
+                username = userData["username"]?.jsonPrimitive?.contentOrNull ?: "",
+                displayName = userData["display_name"]?.jsonPrimitive?.contentOrNull ?: "",
                 email = "",
-                bio = userData["bio"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull,
+                bio = userData["bio"]?.jsonPrimitive?.contentOrNull,
                 avatar = avatarUrl,
-                followersCount = userData["followers_count"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.intOrNull ?: 0,
-                followingCount = userData["following_count"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.intOrNull ?: 0,
-                postsCount = userData["posts_count"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.intOrNull ?: 0,
-                status = UserStatus.fromString(userData["status"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull),
-                account_type = userData["account_type"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull ?: "user",
-                verify = userData["verify"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.booleanOrNull ?: false,
-                banned = userData["banned"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.booleanOrNull ?: false
+                followersCount = userData["followers_count"]?.jsonPrimitive?.intOrNull ?: 0,
+                followingCount = userData["following_count"]?.jsonPrimitive?.intOrNull ?: 0,
+                postsCount = userData["posts_count"]?.jsonPrimitive?.intOrNull ?: 0,
+                status = UserStatus.fromString(userData["status"]?.jsonPrimitive?.contentOrNull),
+                account_type = userData["account_type"]?.jsonPrimitive?.contentOrNull ?: "user",
+                verify = userData["verify"]?.jsonPrimitive?.booleanOrNull ?: false,
+                banned = userData["banned"]?.jsonPrimitive?.booleanOrNull ?: false
             )
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to parse user profile: ${e.message}")
+            Log.e(TAG, "Failed to parse user: ${e.message}")
             null
         }
     }

--- a/app/src/main/java/com/synapse/social/studioasinc/domain/model/Post.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/domain/model/Post.kt
@@ -93,7 +93,7 @@ data class Post(
     @SerialName("reshares_count")
     val resharesCount: Int = 0,
 
-        @SerialName("reply_to_post_id")
+        @SerialName("in_reply_to_post_id")
     val inReplyToPostId: String? = null,
     @SerialName("root_post_id")
     val rootPostId: String? = null,

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
@@ -106,6 +106,9 @@ class ChatViewModel @Inject constructor(
     val messageSuggestionEnabled = getChatSettingsUseCase.messageSuggestionEnabled
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
+    val chatAvatarDisabled = getChatSettingsUseCase.chatAvatarDisabled
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
     private val _selectedMessageIds = MutableStateFlow<Set<String>>(emptySet())
     val selectedMessageIds: StateFlow<Set<String>> = _selectedMessageIds.asStateFlow()
 

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
@@ -19,6 +19,8 @@ import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -62,6 +64,67 @@ import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 import com.synapse.social.studioasinc.feature.shared.theme.Sizes
 
 @Composable
+fun RepliesIndicatorRow(count: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = Spacing.Small),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "$count replies",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        HorizontalDivider(modifier = Modifier.weight(1f).padding(start = Spacing.Small))
+    }
+}
+
+@Composable
+fun SenderHeaderRow(
+    avatarUrl: String?,
+    displayName: String,
+    timestamp: String,
+    isStarred: Boolean
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = Spacing.Small),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            model = avatarUrl,
+            contentDescription = "Sender Avatar",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(36.dp)
+                .clip(androidx.compose.foundation.shape.CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        )
+        Spacer(modifier = Modifier.width(Spacing.Small))
+        Column {
+            Text(
+                text = displayName,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = timestamp,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Icon(
+            imageVector = Icons.Filled.Star,
+            contentDescription = "Starred",
+            tint = if (isStarred) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
 fun DateDividerChip(label: String) {
     Box(
         modifier = Modifier
@@ -85,6 +148,30 @@ fun DateDividerChip(label: String) {
 }
 
 @Composable
+private fun WavyDivider(modifier: Modifier, color: Color) {
+    androidx.compose.foundation.Canvas(modifier = modifier) {
+        val path = androidx.compose.ui.graphics.Path()
+        val waveLength = 12.dp.toPx()
+        val amplitude = 3.dp.toPx()
+        var currentX = 0f
+        path.moveTo(0f, size.height / 2f)
+        while (currentX < size.width) {
+            path.relativeQuadraticTo(waveLength / 4f, -amplitude, waveLength / 2f, 0f)
+            path.relativeQuadraticTo(waveLength / 4f, amplitude, waveLength / 2f, 0f)
+            currentX += waveLength
+        }
+        drawPath(
+            path = path,
+            color = color,
+            style = androidx.compose.ui.graphics.drawscope.Stroke(
+                width = 1.5.dp.toPx(),
+                cap = androidx.compose.ui.graphics.StrokeCap.Round
+            )
+        )
+    }
+}
+
+@Composable
 fun UnreadDividerRow(count: Int) {
     Row(
         modifier = Modifier
@@ -92,14 +179,14 @@ fun UnreadDividerRow(count: Int) {
             .padding(vertical = Spacing.Small),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        HorizontalDivider(modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f))
+        WavyDivider(modifier = Modifier.weight(1f).height(6.dp), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f))
         Text(
             text = stringResource(if (count == 1) R.string.chat_divider_unread_one else R.string.chat_divider_unread_other, count),
             modifier = Modifier.padding(horizontal = Spacing.Medium),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.primary
         )
-        HorizontalDivider(modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f))
+        WavyDivider(modifier = Modifier.weight(1f).height(6.dp), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f))
     }
 }
 
@@ -133,7 +220,12 @@ fun MessageBubble(
     getLinkMetadataUseCase: GetLinkMetadataUseCase? = null,
     fontScale: Float = 1.0f,
     cornerRadius: Int = 16,
-    themePreset: ChatThemePreset = ChatThemePreset.DEFAULT
+    themePreset: ChatThemePreset = ChatThemePreset.DEFAULT,
+    showAvatar: Boolean = true,
+    senderName: String? = null,
+    senderAvatarUrl: String? = null,
+    reactions: List<Pair<String, Int>> = emptyList(),
+    replyCount: Int = 0
 ) {
     val alignment = if (isFromMe) Alignment.CenterEnd else Alignment.CenterStart
 
@@ -141,26 +233,26 @@ fun MessageBubble(
 
     val containerColor = if (isFromMe) {
         when (themePreset) {
-            ChatThemePreset.DEFAULT -> MaterialTheme.colorScheme.primary
+            ChatThemePreset.DEFAULT -> MaterialTheme.colorScheme.primaryContainer
             ChatThemePreset.OCEAN -> if (isDark) DarkPrimaryContainer else LightPrimaryContainer
             ChatThemePreset.FOREST -> if (isDark) ForestBubbleText else ForestBubbleBackground
             ChatThemePreset.SUNSET -> if (isDark) SunsetBubbleText else SunsetBubbleBackground
             ChatThemePreset.MONOCHROME -> if (isDark) Gray700 else Gray200
         }
     } else {
-        MaterialTheme.colorScheme.secondaryContainer
+        MaterialTheme.colorScheme.surfaceContainerHighest
     }
 
     val contentColor = if (isFromMe) {
         when (themePreset) {
-            ChatThemePreset.DEFAULT -> MaterialTheme.colorScheme.onPrimary
+            ChatThemePreset.DEFAULT -> MaterialTheme.colorScheme.onPrimaryContainer
             ChatThemePreset.OCEAN -> if (isDark) DarkOnPrimaryContainer else DarkPrimaryContainer
             ChatThemePreset.FOREST -> if (isDark) ForestBubbleBackground else ForestBubbleText
             ChatThemePreset.SUNSET -> if (isDark) SunsetBubbleBackground else SunsetBubbleText
             ChatThemePreset.MONOCHROME -> if (isDark) Gray200 else Gray900
         }
     } else {
-        MaterialTheme.colorScheme.onSecondaryContainer
+        MaterialTheme.colorScheme.onSurface
     }
 
     // UI logic applied carefully matching sender side for sharpness:
@@ -241,6 +333,17 @@ fun MessageBubble(
             },
         contentAlignment = alignment
     ) {
+        Column(
+            horizontalAlignment = if (isFromMe) Alignment.End else Alignment.Start
+        ) {
+            if (!isFromMe && (position == GroupPosition.SINGLE || position == GroupPosition.FIRST) && showAvatar) {
+                SenderHeaderRow(
+                    avatarUrl = senderAvatarUrl,
+                    displayName = senderName ?: "",
+                    timestamp = formatMessageTime(message.createdAt),
+                    isStarred = false
+                )
+            }
         Surface(
             color = containerColor,
             contentColor = contentColor,
@@ -258,21 +361,28 @@ fun MessageBubble(
                             .fillMaxWidth()
                             .padding(bottom = Spacing.ExtraSmall)
                     ) {
-                        Column(modifier = Modifier.padding(Spacing.Small)) {
-                            Text(
-                                text = if (replyToMessage.senderId == message.senderId) "You" else "Them",
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.primary
-                            )
-                            Text(
-                                text = replyToMessage.content ?: "",
-                                style = androidx.compose.ui.text.TextStyle(
-                                    fontSize = MaterialTheme.typography.bodySmall.fontSize * fontScale,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                ),
-                                maxLines = 1,
-                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
-                            )
+                        Row(modifier = Modifier.padding(Spacing.Small), verticalAlignment = Alignment.CenterVertically) {
+                            Text("❝", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(end = Spacing.ExtraSmall))
+
+                            // Given that we don't have access to the replyToMessage senderName and avatarURL on the base Message data class natively (we'd have to look them up),
+                            // we'll attempt to provide a fallback name for now since we don't have sender name on the model.
+                            // If they were on the model: AsyncImage(model=replyToMessage.senderAvatarUrl) + text=(replyToMessage.senderName ?: "").uppercase()
+                            Column {
+                                Text(
+                                    text = (if (replyToMessage.senderId == message.senderId) "You" else "Them").uppercase(),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                                Text(
+                                    text = replyToMessage.content ?: "",
+                                    style = androidx.compose.ui.text.TextStyle(
+                                        fontSize = MaterialTheme.typography.bodySmall.fontSize * fontScale,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    ),
+                                    maxLines = 1,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                )
+                            }
                         }
                     }
                 }
@@ -449,6 +559,47 @@ fun MessageBubble(
                     }
                 }
             }
+        }
+
+        if (reactions.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = Spacing.ExtraSmall),
+                horizontalArrangement = if (isFromMe) Arrangement.End else Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                reactions.forEach { (emoji, count) ->
+                    Surface(
+                        shape = RoundedCornerShape(50),
+                        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                        color = MaterialTheme.colorScheme.surface,
+                        modifier = Modifier.padding(end = Spacing.ExtraSmall)
+                    ) {
+                        Text(
+                            text = "$emoji $count",
+                            modifier = Modifier.padding(horizontal = Spacing.Small, vertical = Spacing.Tiny),
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+                }
+
+                IconButton(
+                    onClick = onLongClick,
+                    modifier = Modifier.size(24.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.AddReaction,
+                        contentDescription = "Add Reaction",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        if (replyCount > 0) {
+            RepliesIndicatorRow(count = replyCount)
+        }
         }
     }
 }

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
@@ -23,6 +23,16 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.*
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.unit.Dp
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,7 +51,6 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.synapse.social.studioasinc.R
@@ -99,7 +108,7 @@ fun SenderHeaderRow(
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .size(36.dp)
-                .clip(androidx.compose.foundation.shape.CircleShape)
+                .clip(CircleShape)
                 .background(MaterialTheme.colorScheme.surfaceVariant)
         )
         Spacer(modifier = Modifier.width(Spacing.Small))
@@ -149,8 +158,8 @@ fun DateDividerChip(label: String) {
 
 @Composable
 private fun WavyDivider(modifier: Modifier, color: Color) {
-    androidx.compose.foundation.Canvas(modifier = modifier) {
-        val path = androidx.compose.ui.graphics.Path()
+    Canvas(modifier = modifier) {
+        val path = Path()
         val waveLength = 12.dp.toPx()
         val amplitude = 3.dp.toPx()
         var currentX = 0f
@@ -163,9 +172,9 @@ private fun WavyDivider(modifier: Modifier, color: Color) {
         drawPath(
             path = path,
             color = color,
-            style = androidx.compose.ui.graphics.drawscope.Stroke(
+            style = Stroke(
                 width = 1.5.dp.toPx(),
-                cap = androidx.compose.ui.graphics.StrokeCap.Round
+                cap = StrokeCap.Round
             )
         )
     }
@@ -216,6 +225,7 @@ fun MessageBubble(
     onSwipeToReply: () -> Unit = {},
     replyToMessage: Message? = null,
     onLongClick: () -> Unit = {},
+    onShowReactionPicker: () -> Unit = {},
     onReactionSelected: (SharedReactionType) -> Unit = {},
     getLinkMetadataUseCase: GetLinkMetadataUseCase? = null,
     fontScale: Float = 1.0f,
@@ -256,7 +266,7 @@ fun MessageBubble(
     }
 
     // UI logic applied carefully matching sender side for sharpness:
-    val radius = androidx.compose.ui.unit.Dp(cornerRadius.toFloat())
+    val radius = Dp(cornerRadius.toFloat())
     val shape = if (isFromMe) {
         when (position) {
             GroupPosition.SINGLE -> RoundedCornerShape(radius, radius, radius, radius)
@@ -340,7 +350,7 @@ fun MessageBubble(
                 SenderHeaderRow(
                     avatarUrl = senderAvatarUrl,
                     displayName = senderName ?: "",
-                    timestamp = formatMessageTime(message.createdAt),
+                    timestamp = remember(message.createdAt) { formatMessageTime(message.createdAt) },
                     isStarred = false
                 )
             }
@@ -375,12 +385,12 @@ fun MessageBubble(
                                 )
                                 Text(
                                     text = replyToMessage.content ?: "",
-                                    style = androidx.compose.ui.text.TextStyle(
+                                    style = TextStyle(
                                         fontSize = MaterialTheme.typography.bodySmall.fontSize * fontScale,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                     ),
                                     maxLines = 1,
-                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                    overflow = TextOverflow.Ellipsis
                                 )
                             }
                         }
@@ -436,7 +446,7 @@ fun MessageBubble(
                                 color = contentColor,
                                 fontSize = MaterialTheme.typography.bodyMedium.fontSize * fontScale,
                                 maxLines = 1,
-                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                overflow = TextOverflow.Ellipsis
                             )
                         }
                         Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
@@ -479,7 +489,7 @@ fun MessageBubble(
                         var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
                         Text(
                             text = annotatedString,
-                            style = androidx.compose.ui.text.TextStyle(
+                            style = TextStyle(
                                 color = contentColor,
                                 fontSize = MaterialTheme.typography.bodyMedium.fontSize * fontScale,
                             ),
@@ -529,11 +539,11 @@ fun MessageBubble(
                             text = stringResource(id = R.string.edited),
                             style = MaterialTheme.typography.labelSmall,
                             color = contentColor.copy(alpha = 0.6f),
-                            fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
+                            fontStyle = FontStyle.Italic
                         )
                     }
                     Text(
-                        text = formatMessageTime(message.createdAt),
+                        text = remember(message.createdAt) { formatMessageTime(message.createdAt) },
                         style = MaterialTheme.typography.labelSmall,
                         color = contentColor.copy(alpha = 0.6f)
                     )
@@ -572,7 +582,7 @@ fun MessageBubble(
                 reactions.forEach { (emoji, count) ->
                     Surface(
                         shape = RoundedCornerShape(50),
-                        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
                         color = MaterialTheme.colorScheme.surface,
                         modifier = Modifier.padding(end = Spacing.ExtraSmall)
                     ) {
@@ -585,7 +595,7 @@ fun MessageBubble(
                 }
 
                 IconButton(
-                    onClick = onLongClick,
+                    onClick = onShowReactionPicker,
                     modifier = Modifier.size(24.dp)
                 ) {
                     Icon(

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -235,7 +236,8 @@ fun MessageBubble(
     senderName: String? = null,
     senderAvatarUrl: String? = null,
     reactions: List<Pair<String, Int>> = emptyList(),
-    replyCount: Int = 0
+    replyCount: Int = 0,
+    modifier: Modifier = Modifier
 ) {
     val alignment = if (isFromMe) Alignment.CenterEnd else Alignment.CenterStart
 
@@ -292,7 +294,7 @@ fun MessageBubble(
 
     Box(
 
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .background(if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f) else Color.Transparent)
             .combinedClickable(
@@ -341,19 +343,39 @@ fun MessageBubble(
                     }
                 )
             },
-        contentAlignment = alignment
     ) {
-        Column(
-            horizontalAlignment = if (isFromMe) Alignment.End else Alignment.Start
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = if (isFromMe) Arrangement.End else Arrangement.Start
         ) {
-            if (!isFromMe && (position == GroupPosition.SINGLE || position == GroupPosition.FIRST) && showAvatar) {
-                SenderHeaderRow(
-                    avatarUrl = senderAvatarUrl,
-                    displayName = senderName ?: "",
-                    timestamp = remember(message.createdAt) { formatMessageTime(message.createdAt) },
-                    isStarred = false
-                )
+            if (!isFromMe) {
+                if (showAvatar && (position == GroupPosition.LAST || position == GroupPosition.SINGLE)) {
+                    AsyncImage(
+                        model = senderAvatarUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(Sizes.AvatarSmall)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                    )
+                } else {
+                    Spacer(modifier = Modifier.size(Sizes.AvatarSmall))
+                }
+                Spacer(modifier = Modifier.width(Spacing.Small))
             }
+            Column(
+                horizontalAlignment = if (isFromMe) Alignment.End else Alignment.Start
+            ) {
+        if (position == GroupPosition.FIRST || position == GroupPosition.SINGLE) {
+            Text(
+                text = remember(message.createdAt) { formatMessageTime(message.createdAt) },
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                modifier = Modifier.padding(bottom = Spacing.Tiny)
+            )
+        }
         Surface(
             color = containerColor,
             contentColor = contentColor,
@@ -364,24 +386,45 @@ fun MessageBubble(
             Column(modifier = Modifier.padding(horizontal = Spacing.SmallMedium, vertical = Spacing.Small)) {
 
                 if (replyToMessage != null) {
+                    val quoteCardColor = if (isFromMe)
+                        MaterialTheme.colorScheme.surface
+                    else
+                        MaterialTheme.colorScheme.surfaceContainerHigh
                     Surface(
-                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                        color = quoteCardColor,
                         shape = RoundedCornerShape(Sizes.CornerMedium),
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(bottom = Spacing.ExtraSmall)
+                            .padding(bottom = Spacing.Small)
                     ) {
-                        Row(modifier = Modifier.padding(Spacing.Small), verticalAlignment = Alignment.CenterVertically) {
-                            Text("❝", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(end = Spacing.ExtraSmall))
-
-                            // Given that we don't have access to the replyToMessage senderName and avatarURL on the base Message data class natively (we'd have to look them up),
-                            // we'll attempt to provide a fallback name for now since we don't have sender name on the model.
-                            // If they were on the model: AsyncImage(model=replyToMessage.senderAvatarUrl) + text=(replyToMessage.senderName ?: "").uppercase()
+                        Row(
+                            modifier = Modifier.padding(Spacing.Small),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "❝",
+                                style = MaterialTheme.typography.titleLarge,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.padding(end = Spacing.Small)
+                            )
+                            val isOwnReply = replyToMessage.senderId == message.senderId
+                            AsyncImage(
+                                model = if (isOwnReply) null else senderAvatarUrl,
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .size(Sizes.AvatarTiny)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                            )
+                            Spacer(modifier = Modifier.width(Spacing.ExtraSmall))
                             Column {
                                 Text(
-                                    text = (if (replyToMessage.senderId == message.senderId) "You" else "Them").uppercase(),
+                                    text = if (isOwnReply) stringResource(R.string.chat_reply_you)
+                                           else (senderName?.uppercase() ?: stringResource(R.string.chat_reply_them)),
                                     style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.primary
+                                    fontWeight = FontWeight.Bold,
+                                    color = MaterialTheme.colorScheme.onSurface
                                 )
                                 Text(
                                     text = replyToMessage.content ?: "",
@@ -515,60 +558,30 @@ fun MessageBubble(
                 }
 
                 Spacer(modifier = Modifier.height(Spacing.Tiny))
-                Row(
-                    modifier = Modifier.align(Alignment.End),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.ExtraSmall)
-                ) {
-                    if (message.expiresAt != null) {
-                        Icon(
-                            imageVector = Icons.Default.Timer,
-                            contentDescription = "Disappearing Message",
-                            modifier = Modifier.size(Sizes.StatusDot),
-                            tint = contentColor.copy(alpha = 0.6f)
-                        )
-                    }
-                    Icon(
-                        imageVector = Icons.Filled.Lock,
-                        contentDescription = "End-to-End Encrypted",
-                        modifier = Modifier.size(Sizes.StatusDot),
-                        tint = contentColor.copy(alpha = 0.6f)
-                    )
-                    if (message.isEdited) {
-                        Text(
-                            text = stringResource(id = R.string.edited),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = contentColor.copy(alpha = 0.6f),
-                            fontStyle = FontStyle.Italic
-                        )
-                    }
+                if (message.isEdited) {
                     Text(
-                        text = remember(message.createdAt) { formatMessageTime(message.createdAt) },
+                        text = stringResource(id = R.string.edited),
                         style = MaterialTheme.typography.labelSmall,
-                        color = contentColor.copy(alpha = 0.6f)
+                        color = contentColor.copy(alpha = 0.6f),
+                        fontStyle = FontStyle.Italic,
+                        modifier = Modifier.align(Alignment.End)
                     )
-                    if (isFromMe) {
-                        val isRead = message.deliveryStatus == DeliveryStatus.READ
-                        val isSent = message.deliveryStatus == DeliveryStatus.SENT
-                        val iconTint = if (isRead) StatusRead else contentColor.copy(alpha = 0.6f)
-                        if (isSent) {
-                            Icon(
-                                imageVector = Icons.Default.Check,
-                                contentDescription = "Sent",
-                                tint = iconTint,
-                                modifier = Modifier.size(Sizes.IconSemiSmall)
-                            )
-                        } else {
-                            Icon(
-                                imageVector = Icons.Default.DoneAll,
-                                contentDescription = if (isRead) "Read" else "Delivered",
-                                tint = iconTint,
-                                modifier = Modifier.size(Sizes.IconSemiSmall)
-                            )
-                        }
-                    }
                 }
             }
+        }
+
+        if (isFromMe && (position == GroupPosition.LAST || position == GroupPosition.SINGLE)
+            && message.deliveryStatus == DeliveryStatus.READ) {
+            AsyncImage(
+                model = senderAvatarUrl,
+                contentDescription = stringResource(R.string.chat_cd_reader_avatar),
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .padding(top = Spacing.Tiny)
+                    .size(Sizes.AvatarTiny)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+            )
         }
 
         if (reactions.isNotEmpty()) {
@@ -610,7 +623,8 @@ fun MessageBubble(
         if (replyCount > 0) {
             RepliesIndicatorRow(count = replyCount)
         }
-        }
+        } // Column
+        } // Row
     }
 }
 

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
@@ -49,8 +49,8 @@ internal fun ChatMessageList(
             .fillMaxSize(),
         // Extra bottom padding so last messages aren't hidden behind the floating input
         contentPadding = PaddingValues(
-            start = Spacing.Medium,
-            end = Spacing.Medium,
+            start = Spacing.Small,
+            end = Spacing.Small,
             top = Spacing.Medium,
             bottom = Sizes.WidthLarge
         ),

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
@@ -30,6 +30,8 @@ internal fun ChatMessageList(
     chatFontScale: Float,
     chatMessageCornerRadius: Int,
     chatThemePreset: ChatThemePreset,
+    chatAvatarDisabled: Boolean,
+    participantProfile: com.synapse.social.studioasinc.shared.domain.model.User?,
     listState: LazyListState,
     onToggleSelection: (String) -> Unit,
     onSwipeToReply: (Message) -> Unit,
@@ -96,7 +98,10 @@ internal fun ChatMessageList(
                         onReactionSelected = { reaction -> message.id?.let { onReactionSelected(it, reaction) } },
                         fontScale = chatFontScale,
                         cornerRadius = chatMessageCornerRadius,
-                        themePreset = chatThemePreset
+                        themePreset = chatThemePreset,
+                        showAvatar = !chatAvatarDisabled,
+                        senderName = participantProfile?.displayName ?: participantProfile?.name,
+                        senderAvatarUrl = participantProfile?.avatar
                     )
                 }
             }

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
@@ -17,6 +17,7 @@ import com.synapse.social.studioasinc.feature.inbox.inbox.components.isWithinTim
 import com.synapse.social.studioasinc.feature.inbox.inbox.models.ChatListItem
 import com.synapse.social.studioasinc.feature.shared.theme.Sizes
 import com.synapse.social.studioasinc.feature.shared.theme.Spacing
+import com.synapse.social.studioasinc.shared.core.network.SupabaseClient
 import com.synapse.social.studioasinc.shared.domain.model.chat.Message
 import com.synapse.social.studioasinc.shared.domain.model.settings.ChatThemePreset
 import com.synapse.social.studioasinc.shared.domain.model.ReactionType as SharedReactionType
@@ -102,7 +103,9 @@ internal fun ChatMessageList(
                         themePreset = chatThemePreset,
                         showAvatar = !chatAvatarDisabled,
                         senderName = participantProfile?.displayName ?: participantProfile?.name,
-                        senderAvatarUrl = participantProfile?.avatar
+                        senderAvatarUrl = participantProfile?.avatar?.let {
+                            if (it.startsWith("http")) it else SupabaseClient.constructAvatarUrl(it)
+                        }
                     )
                 }
             }

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
@@ -1,8 +1,8 @@
 package com.synapse.social.studioasinc.feature.inbox.inbox.screens
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -53,7 +53,6 @@ internal fun ChatMessageList(
             top = Spacing.Medium,
             bottom = Sizes.WidthLarge
         ),
-        verticalArrangement = Arrangement.spacedBy(Spacing.ExtraSmall),
         reverseLayout = true
     ) {
         val reversedItems = chatItems.reversed()
@@ -80,7 +79,9 @@ internal fun ChatMessageList(
                         else -> GroupPosition.MIDDLE
                     }
                     val isSelected = message.id in selectedMessageIds
+                    val bottomGap = if (position == GroupPosition.LAST || position == GroupPosition.SINGLE) Spacing.Small else Spacing.Tiny
                     MessageBubble(
+                        modifier = Modifier.padding(bottom = bottomGap),
                         message = message,
                         isFromMe = message.isFromMe(currentUserId),
                         position = position,

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
@@ -192,7 +192,7 @@ fun ChatScreen(
     val chatFontScale by viewModel.chatFontScale.collectAsState()
     val chatThemePreset by viewModel.chatThemePreset.collectAsState()
     val chatMessageCornerRadius by viewModel.chatMessageCornerRadius.collectAsState()
-
+    val chatAvatarDisabled by viewModel.chatAvatarDisabled.collectAsState()
 
     var selectedMessageForMenu by remember { mutableStateOf<Message?>(null) }
 
@@ -317,6 +317,8 @@ fun ChatScreen(
                         chatFontScale = chatFontScale,
                         chatMessageCornerRadius = chatMessageCornerRadius,
                         chatThemePreset = chatThemePreset,
+                        chatAvatarDisabled = chatAvatarDisabled,
+                        participantProfile = participantProfile,
                         listState = listState,
                         onToggleSelection = { viewModel.toggleMessageSelection(it) },
                         onSwipeToReply = { viewModel.setReplyingToMessage(it) },

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/post/postdetail/components/CommentInput.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/post/postdetail/components/CommentInput.kt
@@ -80,9 +80,16 @@ fun CommentInput(
 
             Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(Spacing.ExtraSmall)) {
                 if (replyToParticipants.isNotEmpty()) {
-                    val label = when {
-                        replyToParticipants.size == 1 -> "Replying to @${replyToParticipants[0]}"
-                        else -> "Replying to @${replyToParticipants[0]} and ${replyToParticipants.size - 1} others"
+                    val maxShown = 3
+                    val shown = replyToParticipants.take(maxShown)
+                    val overflow = replyToParticipants.size - shown.size
+                    val label = buildString {
+                        append("Replying to ")
+                        shown.forEachIndexed { i, username ->
+                            if (i > 0) append(if (i == shown.lastIndex && overflow == 0) " and " else ", ")
+                            append("@$username")
+                        }
+                        if (overflow > 0) append(" and $overflow other${if (overflow > 1) "s" else ""}")
                     }
                     Text(
                         text = label,

--- a/app/src/main/java/com/synapse/social/studioasinc/shared/domain/usecase/chat/GetChatSettingsUseCase.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/shared/domain/usecase/chat/GetChatSettingsUseCase.kt
@@ -17,4 +17,5 @@ class GetChatSettingsUseCase @Inject constructor(
     val chatMessageCornerRadius: Flow<Int> = settingsRepository.chatMessageCornerRadius
     val chatMaxMessageChunkSize: Flow<Int> = settingsRepository.chatMaxMessageChunkSize
     val messageSuggestionEnabled: Flow<Boolean> = settingsRepository.messageSuggestionEnabled
+    val chatAvatarDisabled: Flow<Boolean> = settingsRepository.chatAvatarDisabled
 }

--- a/app/src/main/java/com/synapse/social/studioasinc/ui/settings/FlagsScreen.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/ui/settings/FlagsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -19,6 +20,7 @@ fun FlagsScreen(
     onBackClick: () -> Unit
 ) {
     val messageSuggestionEnabled by viewModel.messageSuggestionEnabled.collectAsState()
+    val chatAvatarDisabled by viewModel.chatAvatarDisabled.collectAsState()
 
     Scaffold(
         containerColor = SettingsColors.screenBackground,
@@ -61,7 +63,15 @@ fun FlagsScreen(
                             imageVector = Icons.Filled.Build,
                             checked = messageSuggestionEnabled,
                             onCheckedChange = { viewModel.setMessageSuggestionEnabled(it) },
-                            position = SettingsItemPosition.Single
+                            position = SettingsItemPosition.Top
+                        )
+                        SettingsToggleItem(
+                            title = "Disable Chat Avatars",
+                            subtitle = "Hide sender avatars in chat",
+                            imageVector = Icons.Filled.Person,
+                            checked = chatAvatarDisabled,
+                            onCheckedChange = { viewModel.setChatAvatarDisabled(it) },
+                            position = SettingsItemPosition.Bottom
                         )
                     }
                 }

--- a/app/src/main/java/com/synapse/social/studioasinc/ui/settings/FlagsViewModel.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/ui/settings/FlagsViewModel.kt
@@ -22,9 +22,22 @@ class FlagsViewModel @Inject constructor(
             initialValue = false
         )
 
+    val chatAvatarDisabled: StateFlow<Boolean> = settingsRepository.chatAvatarDisabled
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false
+        )
+
     fun setMessageSuggestionEnabled(enabled: Boolean) {
         viewModelScope.launch {
             settingsRepository.setMessageSuggestionEnabled(enabled)
+        }
+    }
+
+    fun setChatAvatarDisabled(disabled: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.setChatAvatarDisabled(disabled)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1329,6 +1329,9 @@ Please explain the following message from %3$s in detail, considering the contex
     <string name="chat_action_open_file">Open File</string>
     <string name="chat_action_open_link">Open Link</string>
     <string name="chat_cd_file">File</string>
+    <string name="chat_reply_you">YOU</string>
+    <string name="chat_reply_them">THEM</string>
+    <string name="chat_cd_reader_avatar">Read by</string>
     <string name="chat_type_message">Type a message...</string>
     <string name="user_created_title">Account Created!</string>
     <string name="user_created_message">Your account has been created successfully. Please check your email to verify your account.</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Build configuration
-projectVersion=0.2.0
+projectVersion=0.3.0
 android.suppressUnsupportedCompileSdk=36
 android.enableR8.fullMode=false
 android.enableJetifier=true

--- a/shared/src/commonMain/sqldelight/com/synapse/social/studioasinc/shared/data/database/5.sqm
+++ b/shared/src/commonMain/sqldelight/com/synapse/social/studioasinc/shared/data/database/5.sqm
@@ -1,0 +1,7 @@
+CREATE TABLE MessageReaction (
+    message_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    reaction_emoji TEXT NOT NULL,
+    timestamp INTEGER NOT NULL,
+    PRIMARY KEY (message_id, user_id, reaction_emoji)
+);

--- a/shared/src/commonMain/sqldelight/com/synapse/social/studioasinc/shared/data/database/MessageReaction.sq
+++ b/shared/src/commonMain/sqldelight/com/synapse/social/studioasinc/shared/data/database/MessageReaction.sq
@@ -1,0 +1,26 @@
+CREATE TABLE MessageReaction (
+    message_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    reaction_emoji TEXT NOT NULL,
+    timestamp INTEGER NOT NULL,
+    PRIMARY KEY (message_id, user_id, reaction_emoji)
+);
+
+insertReaction:
+INSERT OR REPLACE INTO MessageReaction(message_id, user_id, reaction_emoji, timestamp)
+VALUES ?;
+
+deleteReaction:
+DELETE FROM MessageReaction
+WHERE message_id = :messageId AND user_id = :userId AND reaction_emoji = :reactionEmoji;
+
+selectByMessageId:
+SELECT * FROM MessageReaction
+WHERE message_id = :messageId;
+
+deleteAllByMessageId:
+DELETE FROM MessageReaction
+WHERE message_id = :messageId;
+
+deleteAll:
+DELETE FROM MessageReaction;


### PR DESCRIPTION
🐛 fix: Refactor comments to X-style threaded posts

- Fix Post.kt SerialName: reply_to_post_id → in_reply_to_post_id
- Rewrite CommentRemoteDataSource to query posts table instead of deleted comments table
- Redirect comment reactions from comment_reactions to reactions table (post_id)
- Update getTableName/getIdColumn: comment type now maps to reactions/post_id
- Simplify populateCommentReactions to use reactions table directly
- CommentInput: show up to 3 usernames in reply label, then 'and N others'
- reportComment now inserts into reports table with target_type='comment'