### PR TITLE
feat(chat): Implement avatar disable flag & UI prototype updates

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/data/local/database/SettingsDataStore.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/local/database/SettingsDataStore.kt
@@ -71,6 +71,7 @@ class SettingsDataStore private constructor(
             preferences.remove(SettingsConstants.KEY_CHAT_FOLDERS)
             preferences.remove(SettingsConstants.KEY_CHAT_MAX_MESSAGE_CHUNK_SIZE)
             preferences.remove(SettingsConstants.KEY_MESSAGE_SUGGESTION_ENABLED)
+            preferences.remove(SettingsConstants.KEY_CHAT_AVATAR_DISABLED)
 
             preferences.remove(SettingsConstants.KEY_DATA_SAVER_ENABLED)
 
@@ -126,6 +127,7 @@ class SettingsDataStore private constructor(
             preferences.remove(SettingsConstants.KEY_CHAT_FOLDERS)
             preferences[SettingsConstants.KEY_CHAT_MAX_MESSAGE_CHUNK_SIZE] = SettingsConstants.DEFAULT_CHAT_MAX_MESSAGE_CHUNK_SIZE
             preferences[SettingsConstants.KEY_MESSAGE_SUGGESTION_ENABLED] = SettingsConstants.DEFAULT_MESSAGE_SUGGESTION_ENABLED
+            preferences[SettingsConstants.KEY_CHAT_AVATAR_DISABLED] = SettingsConstants.DEFAULT_CHAT_AVATAR_DISABLED
 
             preferences[SettingsConstants.KEY_DATA_SAVER_ENABLED] = SettingsConstants.DEFAULT_DATA_SAVER_ENABLED
 

--- a/app/src/main/java/com/synapse/social/studioasinc/data/local/database/settings/ChatStore.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/local/database/settings/ChatStore.kt
@@ -19,6 +19,7 @@ interface ChatStore {
     val chatSwipeGesture: Flow<com.synapse.social.studioasinc.shared.domain.model.settings.ChatSwipeGesture>
     val chatMaxMessageChunkSize: Flow<Int>
     val chatFoldersJson: Flow<String?>
+    val chatAvatarDisabled: Flow<Boolean>
 
     suspend fun setChatFontScale(scale: Float)
     suspend fun setChatThemePreset(preset: ChatThemePreset)
@@ -30,6 +31,7 @@ interface ChatStore {
     suspend fun setChatSwipeGesture(gesture: com.synapse.social.studioasinc.shared.domain.model.settings.ChatSwipeGesture)
     suspend fun setChatMaxMessageChunkSize(size: Int)
     suspend fun setChatFoldersJson(json: String)
+    suspend fun setChatAvatarDisabled(enabled: Boolean)
 }
 
 class ChatStoreImpl(private val dataStore: DataStore<Preferences>) : ChatStore {
@@ -143,6 +145,16 @@ class ChatStoreImpl(private val dataStore: DataStore<Preferences>) : ChatStore {
     override suspend fun setChatFoldersJson(json: String) {
         dataStore.edit { preferences ->
             preferences[SettingsConstants.KEY_CHAT_FOLDERS] = json
+        }
+    }
+
+    override val chatAvatarDisabled: Flow<Boolean> = dataStore.safePreferencesFlow().map { preferences ->
+        preferences[SettingsConstants.KEY_CHAT_AVATAR_DISABLED] ?: SettingsConstants.DEFAULT_CHAT_AVATAR_DISABLED
+    }
+
+    override suspend fun setChatAvatarDisabled(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[SettingsConstants.KEY_CHAT_AVATAR_DISABLED] = enabled
         }
     }
 }

--- a/app/src/main/java/com/synapse/social/studioasinc/data/local/database/settings/SettingsConstants.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/local/database/settings/SettingsConstants.kt
@@ -61,6 +61,7 @@ object SettingsConstants {
     val KEY_AI_FALLBACK_TO_PLATFORM = booleanPreferencesKey("ai_fallback_to_platform")
     val KEY_AI_CUSTOM_MODEL = stringPreferencesKey("ai_custom_model")
     val KEY_MESSAGE_SUGGESTION_ENABLED = booleanPreferencesKey("message_suggestion_enabled")
+    val KEY_CHAT_AVATAR_DISABLED = booleanPreferencesKey("chat_avatar_disabled")
 
     val KEY_DATA_SAVER_ENABLED = booleanPreferencesKey("data_saver_enabled")
 
@@ -110,6 +111,7 @@ object SettingsConstants {
     val DEFAULT_CHAT_SWIPE_GESTURE = com.synapse.social.studioasinc.shared.domain.model.settings.ChatSwipeGesture.ARCHIVE
     val DEFAULT_CHAT_MAX_MESSAGE_CHUNK_SIZE = 500
     val DEFAULT_MESSAGE_SUGGESTION_ENABLED = false
+    val DEFAULT_CHAT_AVATAR_DISABLED = false
     val DEFAULT_DATA_SAVER_ENABLED = false
     val DEFAULT_ENTER_IS_SEND_ENABLED = false
     val DEFAULT_MEDIA_VISIBILITY_ENABLED = true

--- a/app/src/main/java/com/synapse/social/studioasinc/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/repository/SettingsRepository.kt
@@ -157,6 +157,9 @@ interface SettingsRepository {
     val messageSuggestionEnabled: Flow<Boolean>
     suspend fun setMessageSuggestionEnabled(enabled: Boolean)
 
+    val chatAvatarDisabled: Flow<Boolean>
+    suspend fun setChatAvatarDisabled(enabled: Boolean)
+
     val chatMaxMessageChunkSize: Flow<Int>
     suspend fun setChatMaxMessageChunkSize(size: Int)
 

--- a/app/src/main/java/com/synapse/social/studioasinc/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/data/repository/SettingsRepositoryImpl.kt
@@ -206,6 +206,12 @@ class SettingsRepositoryImpl private constructor(
         settingsDataStore.setMessageSuggestionEnabled(enabled)
     }
 
+    override val chatAvatarDisabled: Flow<Boolean> = settingsDataStore.chatAvatarDisabled
+
+    override suspend fun setChatAvatarDisabled(enabled: Boolean) {
+        settingsDataStore.setChatAvatarDisabled(enabled)
+    }
+
     override val chatMaxMessageChunkSize: Flow<Int> = settingsDataStore.chatMaxMessageChunkSize
 
     override suspend fun setChatMaxMessageChunkSize(size: Int) {

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
@@ -106,6 +106,9 @@ class ChatViewModel @Inject constructor(
     val messageSuggestionEnabled = getChatSettingsUseCase.messageSuggestionEnabled
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
+    val chatAvatarDisabled = getChatSettingsUseCase.chatAvatarDisabled
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
     private val _selectedMessageIds = MutableStateFlow<Set<String>>(emptySet())
     val selectedMessageIds: StateFlow<Set<String>> = _selectedMessageIds.asStateFlow()
 

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
@@ -19,6 +19,8 @@ import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -62,6 +64,67 @@ import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 import com.synapse.social.studioasinc.feature.shared.theme.Sizes
 
 @Composable
+fun RepliesIndicatorRow(count: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = Spacing.Small),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "$count replies",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        HorizontalDivider(modifier = Modifier.weight(1f).padding(start = Spacing.Small))
+    }
+}
+
+@Composable
+fun SenderHeaderRow(
+    avatarUrl: String?,
+    displayName: String,
+    timestamp: String,
+    isStarred: Boolean
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = Spacing.Small),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            model = avatarUrl,
+            contentDescription = "Sender Avatar",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(36.dp)
+                .clip(androidx.compose.foundation.shape.CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        )
+        Spacer(modifier = Modifier.width(Spacing.Small))
+        Column {
+            Text(
+                text = displayName,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = timestamp,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Icon(
+            imageVector = Icons.Filled.Star,
+            contentDescription = "Starred",
+            tint = if (isStarred) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
 fun DateDividerChip(label: String) {
     Box(
         modifier = Modifier
@@ -85,6 +148,30 @@ fun DateDividerChip(label: String) {
 }
 
 @Composable
+private fun WavyDivider(modifier: Modifier, color: Color) {
+    androidx.compose.foundation.Canvas(modifier = modifier) {
+        val path = androidx.compose.ui.graphics.Path()
+        val waveLength = 12.dp.toPx()
+        val amplitude = 3.dp.toPx()
+        var currentX = 0f
+        path.moveTo(0f, size.height / 2f)
+        while (currentX < size.width) {
+            path.relativeQuadraticTo(waveLength / 4f, -amplitude, waveLength / 2f, 0f)
+            path.relativeQuadraticTo(waveLength / 4f, amplitude, waveLength / 2f, 0f)
+            currentX += waveLength
+        }
+        drawPath(
+            path = path,
+            color = color,
+            style = androidx.compose.ui.graphics.drawscope.Stroke(
+                width = 1.5.dp.toPx(),
+                cap = androidx.compose.ui.graphics.StrokeCap.Round
+            )
+        )
+    }
+}
+
+@Composable
 fun UnreadDividerRow(count: Int) {
     Row(
         modifier = Modifier
@@ -92,14 +179,14 @@ fun UnreadDividerRow(count: Int) {
             .padding(vertical = Spacing.Small),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        HorizontalDivider(modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f))
+        WavyDivider(modifier = Modifier.weight(1f).height(6.dp), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f))
         Text(
             text = stringResource(if (count == 1) R.string.chat_divider_unread_one else R.string.chat_divider_unread_other, count),
             modifier = Modifier.padding(horizontal = Spacing.Medium),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.primary
         )
-        HorizontalDivider(modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f))
+        WavyDivider(modifier = Modifier.weight(1f).height(6.dp), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f))
     }
 }
 
@@ -133,7 +220,12 @@ fun MessageBubble(
     getLinkMetadataUseCase: GetLinkMetadataUseCase? = null,
     fontScale: Float = 1.0f,
     cornerRadius: Int = 16,
-    themePreset: ChatThemePreset = ChatThemePreset.DEFAULT
+    themePreset: ChatThemePreset = ChatThemePreset.DEFAULT,
+    showAvatar: Boolean = true,
+    senderName: String? = null,
+    senderAvatarUrl: String? = null,
+    reactions: List<Pair<String, Int>> = emptyList(),
+    replyCount: Int = 0
 ) {
     val alignment = if (isFromMe) Alignment.CenterEnd else Alignment.CenterStart
 
@@ -141,26 +233,26 @@ fun MessageBubble(
 
     val containerColor = if (isFromMe) {
         when (themePreset) {
-            ChatThemePreset.DEFAULT -> MaterialTheme.colorScheme.primary
+            ChatThemePreset.DEFAULT -> MaterialTheme.colorScheme.primaryContainer
             ChatThemePreset.OCEAN -> if (isDark) DarkPrimaryContainer else LightPrimaryContainer
             ChatThemePreset.FOREST -> if (isDark) ForestBubbleText else ForestBubbleBackground
             ChatThemePreset.SUNSET -> if (isDark) SunsetBubbleText else SunsetBubbleBackground
             ChatThemePreset.MONOCHROME -> if (isDark) Gray700 else Gray200
         }
     } else {
-        MaterialTheme.colorScheme.secondaryContainer
+        MaterialTheme.colorScheme.surfaceContainerHighest
     }
 
     val contentColor = if (isFromMe) {
         when (themePreset) {
-            ChatThemePreset.DEFAULT -> MaterialTheme.colorScheme.onPrimary
+            ChatThemePreset.DEFAULT -> MaterialTheme.colorScheme.onPrimaryContainer
             ChatThemePreset.OCEAN -> if (isDark) DarkOnPrimaryContainer else DarkPrimaryContainer
             ChatThemePreset.FOREST -> if (isDark) ForestBubbleBackground else ForestBubbleText
             ChatThemePreset.SUNSET -> if (isDark) SunsetBubbleBackground else SunsetBubbleText
             ChatThemePreset.MONOCHROME -> if (isDark) Gray200 else Gray900
         }
     } else {
-        MaterialTheme.colorScheme.onSecondaryContainer
+        MaterialTheme.colorScheme.onSurface
     }
 
     // UI logic applied carefully matching sender side for sharpness:
@@ -241,6 +333,17 @@ fun MessageBubble(
             },
         contentAlignment = alignment
     ) {
+        Column(
+            horizontalAlignment = if (isFromMe) Alignment.End else Alignment.Start
+        ) {
+            if (!isFromMe && (position == GroupPosition.SINGLE || position == GroupPosition.FIRST) && showAvatar) {
+                SenderHeaderRow(
+                    avatarUrl = senderAvatarUrl,
+                    displayName = senderName ?: "",
+                    timestamp = formatMessageTime(message.createdAt),
+                    isStarred = false
+                )
+            }
         Surface(
             color = containerColor,
             contentColor = contentColor,
@@ -258,21 +361,28 @@ fun MessageBubble(
                             .fillMaxWidth()
                             .padding(bottom = Spacing.ExtraSmall)
                     ) {
-                        Column(modifier = Modifier.padding(Spacing.Small)) {
-                            Text(
-                                text = if (replyToMessage.senderId == message.senderId) "You" else "Them",
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.primary
-                            )
-                            Text(
-                                text = replyToMessage.content ?: "",
-                                style = androidx.compose.ui.text.TextStyle(
-                                    fontSize = MaterialTheme.typography.bodySmall.fontSize * fontScale,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                ),
-                                maxLines = 1,
-                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
-                            )
+                        Row(modifier = Modifier.padding(Spacing.Small), verticalAlignment = Alignment.CenterVertically) {
+                            Text("❝", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(end = Spacing.ExtraSmall))
+
+                            // Given that we don't have access to the replyToMessage senderName and avatarURL on the base Message data class natively (we'd have to look them up),
+                            // we'll attempt to provide a fallback name for now since we don't have sender name on the model.
+                            // If they were on the model: AsyncImage(model=replyToMessage.senderAvatarUrl) + text=(replyToMessage.senderName ?: "").uppercase()
+                            Column {
+                                Text(
+                                    text = (if (replyToMessage.senderId == message.senderId) "You" else "Them").uppercase(),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                                Text(
+                                    text = replyToMessage.content ?: "",
+                                    style = androidx.compose.ui.text.TextStyle(
+                                        fontSize = MaterialTheme.typography.bodySmall.fontSize * fontScale,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    ),
+                                    maxLines = 1,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                )
+                            }
                         }
                     }
                 }
@@ -449,6 +559,47 @@ fun MessageBubble(
                     }
                 }
             }
+        }
+
+        if (reactions.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = Spacing.ExtraSmall),
+                horizontalArrangement = if (isFromMe) Arrangement.End else Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                reactions.forEach { (emoji, count) ->
+                    Surface(
+                        shape = RoundedCornerShape(50),
+                        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                        color = MaterialTheme.colorScheme.surface,
+                        modifier = Modifier.padding(end = Spacing.ExtraSmall)
+                    ) {
+                        Text(
+                            text = "$emoji $count",
+                            modifier = Modifier.padding(horizontal = Spacing.Small, vertical = Spacing.Tiny),
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+                }
+
+                IconButton(
+                    onClick = onLongClick,
+                    modifier = Modifier.size(24.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.AddReaction,
+                        contentDescription = "Add Reaction",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        if (replyCount > 0) {
+            RepliesIndicatorRow(count = replyCount)
+        }
         }
     }
 }

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
@@ -30,6 +30,8 @@ internal fun ChatMessageList(
     chatFontScale: Float,
     chatMessageCornerRadius: Int,
     chatThemePreset: ChatThemePreset,
+    chatAvatarDisabled: Boolean,
+    participantProfile: com.synapse.social.studioasinc.shared.domain.model.User?,
     listState: LazyListState,
     onToggleSelection: (String) -> Unit,
     onSwipeToReply: (Message) -> Unit,
@@ -96,7 +98,10 @@ internal fun ChatMessageList(
                         onReactionSelected = { reaction -> message.id?.let { onReactionSelected(it, reaction) } },
                         fontScale = chatFontScale,
                         cornerRadius = chatMessageCornerRadius,
-                        themePreset = chatThemePreset
+                        themePreset = chatThemePreset,
+                        showAvatar = !chatAvatarDisabled,
+                        senderName = participantProfile?.displayName ?: participantProfile?.name,
+                        senderAvatarUrl = participantProfile?.avatar
                     )
                 }
             }

--- a/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
@@ -192,7 +192,7 @@ fun ChatScreen(
     val chatFontScale by viewModel.chatFontScale.collectAsState()
     val chatThemePreset by viewModel.chatThemePreset.collectAsState()
     val chatMessageCornerRadius by viewModel.chatMessageCornerRadius.collectAsState()
-
+    val chatAvatarDisabled by viewModel.chatAvatarDisabled.collectAsState()
 
     var selectedMessageForMenu by remember { mutableStateOf<Message?>(null) }
 
@@ -317,6 +317,8 @@ fun ChatScreen(
                         chatFontScale = chatFontScale,
                         chatMessageCornerRadius = chatMessageCornerRadius,
                         chatThemePreset = chatThemePreset,
+                        chatAvatarDisabled = chatAvatarDisabled,
+                        participantProfile = participantProfile,
                         listState = listState,
                         onToggleSelection = { viewModel.toggleMessageSelection(it) },
                         onSwipeToReply = { viewModel.setReplyingToMessage(it) },

--- a/app/src/main/java/com/synapse/social/studioasinc/shared/domain/usecase/chat/GetChatSettingsUseCase.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/shared/domain/usecase/chat/GetChatSettingsUseCase.kt
@@ -17,4 +17,5 @@ class GetChatSettingsUseCase @Inject constructor(
     val chatMessageCornerRadius: Flow<Int> = settingsRepository.chatMessageCornerRadius
     val chatMaxMessageChunkSize: Flow<Int> = settingsRepository.chatMaxMessageChunkSize
     val messageSuggestionEnabled: Flow<Boolean> = settingsRepository.messageSuggestionEnabled
+    val chatAvatarDisabled: Flow<Boolean> = settingsRepository.chatAvatarDisabled
 }

--- a/app/src/main/java/com/synapse/social/studioasinc/ui/settings/FlagsScreen.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/ui/settings/FlagsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -19,6 +20,7 @@ fun FlagsScreen(
     onBackClick: () -> Unit
 ) {
     val messageSuggestionEnabled by viewModel.messageSuggestionEnabled.collectAsState()
+    val chatAvatarDisabled by viewModel.chatAvatarDisabled.collectAsState()
 
     Scaffold(
         containerColor = SettingsColors.screenBackground,
@@ -61,7 +63,15 @@ fun FlagsScreen(
                             imageVector = Icons.Filled.Build,
                             checked = messageSuggestionEnabled,
                             onCheckedChange = { viewModel.setMessageSuggestionEnabled(it) },
-                            position = SettingsItemPosition.Single
+                            position = SettingsItemPosition.Top
+                        )
+                        SettingsToggleItem(
+                            title = "Disable Chat Avatars",
+                            subtitle = "Hide sender avatars in chat",
+                            imageVector = Icons.Filled.Person,
+                            checked = chatAvatarDisabled,
+                            onCheckedChange = { viewModel.setChatAvatarDisabled(it) },
+                            position = SettingsItemPosition.Bottom
                         )
                     }
                 }

--- a/app/src/main/java/com/synapse/social/studioasinc/ui/settings/FlagsViewModel.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/ui/settings/FlagsViewModel.kt
@@ -22,9 +22,22 @@ class FlagsViewModel @Inject constructor(
             initialValue = false
         )
 
+    val chatAvatarDisabled: StateFlow<Boolean> = settingsRepository.chatAvatarDisabled
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false
+        )
+
     fun setMessageSuggestionEnabled(enabled: Boolean) {
         viewModelScope.launch {
             settingsRepository.setMessageSuggestionEnabled(enabled)
+        }
+    }
+
+    fun setChatAvatarDisabled(disabled: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.setChatAvatarDisabled(disabled)
         }
     }
 }


### PR DESCRIPTION
This submit introduces the complete end-to-end logic required to disable chat avatars as requested by the user, alongside implementing several new UI refinements per the prototype updates.

- Data Layer extensions for `KEY_CHAT_AVATAR_DISABLED`
- Modified `MessageBubble` colors for `ChatThemePreset.DEFAULT`
- Implemented new `SenderHeaderRow`, a canvas-based `WavyDivider`, reaction chips, and `RepliesIndicatorRow`.
- Attached the setting securely to `FlagsScreen`.

---
*PR created automatically by Jules for task [13429594306957662655](https://jules.google.com/task/13429594306957662655) started by @TheRealAshik*