### PR TITLE
Refactor ChatScreen shimmer layout

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatShimmer.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatShimmer.kt
@@ -20,14 +20,13 @@ import com.synapse.social.studioasinc.feature.shared.theme.Sizes
 @Composable
 fun ChatShimmer(
     modifier: Modifier = Modifier,
-    messageCount: Int = 10
+    messageCount: Int = 5
 ) {
     val listState = rememberLazyListState()
     
     LazyColumn(
         modifier = modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .wrapContentHeight(),
         state = listState,
         contentPadding = PaddingValues(Spacing.Medium),
         verticalArrangement = Arrangement.spacedBy(Spacing.Small),

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
@@ -292,17 +292,20 @@ fun ChatScreen(
                 .imePadding()
         ) {
 
-            if (!isLoading || messages.isNotEmpty()) {
-                ChatBackground(
-                    chatWallpaperType = chatWallpaperType,
-                    chatWallpaperValue = chatWallpaperValue,
-                    chatWallpaperBlur = chatWallpaperBlur
-                )
-            }
+            ChatBackground(
+                chatWallpaperType = chatWallpaperType,
+                chatWallpaperValue = chatWallpaperValue,
+                chatWallpaperBlur = chatWallpaperBlur
+            )
 
             when {
                 isLoading && messages.isEmpty() -> {
-                    ChatShimmer(modifier = Modifier.fillMaxSize())
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.BottomCenter
+                    ) {
+                        ChatShimmer(modifier = Modifier.fillMaxWidth())
+                    }
                 }
                 error != null && messages.isEmpty() -> {
                     Column(


### PR DESCRIPTION
Refactored the initial loading shimmer on `ChatScreen` to improve the UX. Instead of a solid background filling the entire screen, it now displays the actual chat background with 5 shimmer message bubbles anchored to the bottom.

---
*PR created automatically by Jules for task [15765088961042100215](https://jules.google.com/task/15765088961042100215) started by @TheRealAshik*