### PR TITLE
✨ feat: Add FontScreen under Settings > Appearance

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/local/database/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/local/database/SettingsDataStore.kt
@@ -84,6 +84,7 @@ class SettingsDataStore private constructor(
             preferences.remove(SettingsConstants.KEY_ACCOUNT_REPORTS_AUTO_CREATE)
             preferences.remove(SettingsConstants.KEY_CHANNELS_REPORTS_AUTO_CREATE)
             preferences.remove(SettingsConstants.KEY_HIDE_PROFILE_PIC_SUGGESTION)
+            preferences.remove(SettingsConstants.KEY_SELECTED_FONT_ID)
         }
     }
 
@@ -99,6 +100,7 @@ class SettingsDataStore private constructor(
             preferences[SettingsConstants.KEY_DYNAMIC_COLOR_ENABLED] = SettingsConstants.DEFAULT_DYNAMIC_COLOR_ENABLED
             preferences[SettingsConstants.KEY_FONT_SCALE] = SettingsConstants.DEFAULT_FONT_SCALE.name
             preferences[SettingsConstants.KEY_APP_LANGUAGE] = SettingsConstants.DEFAULT_APP_LANGUAGE
+            preferences[SettingsConstants.KEY_SELECTED_FONT_ID] = SettingsConstants.DEFAULT_SELECTED_FONT_ID
 
             preferences[SettingsConstants.KEY_PROFILE_VISIBILITY] = SettingsConstants.DEFAULT_PROFILE_VISIBILITY.name
             preferences[SettingsConstants.KEY_CONTENT_VISIBILITY] = SettingsConstants.DEFAULT_CONTENT_VISIBILITY.name

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/local/database/settings/AppearanceStore.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/local/database/settings/AppearanceStore.kt
@@ -14,11 +14,13 @@ interface AppearanceStore {
     val dynamicColorEnabled: Flow<Boolean>
     val fontScale: Flow<FontScale>
     val appearanceSettings: Flow<AppearanceSettings>
+    val selectedFontId: Flow<String>
 
     suspend fun setThemeMode(mode: ThemeMode)
     suspend fun setDynamicColorEnabled(enabled: Boolean)
     suspend fun setFontScale(scale: FontScale)
     suspend fun setPostViewStyle(style: com.synapse.social.studioasinc.ui.settings.PostViewStyle)
+    suspend fun setSelectedFontId(id: String)
 }
 
 class AppearanceStoreImpl(private val dataStore: DataStore<Preferences>) : AppearanceStore {
@@ -50,8 +52,13 @@ class AppearanceStoreImpl(private val dataStore: DataStore<Preferences>) : Appea
             postViewStyle = preferences[SettingsConstants.KEY_POST_VIEW_STYLE]?.let { value ->
                 runCatching { com.synapse.social.studioasinc.ui.settings.PostViewStyle.valueOf(value) }
                     .getOrDefault(com.synapse.social.studioasinc.ui.settings.PostViewStyle.SWIPE)
-            } ?: com.synapse.social.studioasinc.ui.settings.PostViewStyle.SWIPE
+            } ?: com.synapse.social.studioasinc.ui.settings.PostViewStyle.SWIPE,
+            selectedFontId = preferences[SettingsConstants.KEY_SELECTED_FONT_ID] ?: SettingsConstants.DEFAULT_SELECTED_FONT_ID
         )
+    }
+
+    override val selectedFontId: Flow<String> = dataStore.safePreferencesFlow().map { preferences ->
+        preferences[SettingsConstants.KEY_SELECTED_FONT_ID] ?: SettingsConstants.DEFAULT_SELECTED_FONT_ID
     }
 
     override suspend fun setThemeMode(mode: ThemeMode) {
@@ -75,6 +82,12 @@ class AppearanceStoreImpl(private val dataStore: DataStore<Preferences>) : Appea
     override suspend fun setPostViewStyle(style: com.synapse.social.studioasinc.ui.settings.PostViewStyle) {
         dataStore.edit { preferences ->
             preferences[SettingsConstants.KEY_POST_VIEW_STYLE] = style.name
+        }
+    }
+
+    override suspend fun setSelectedFontId(id: String) {
+        dataStore.edit { preferences ->
+            preferences[SettingsConstants.KEY_SELECTED_FONT_ID] = id
         }
     }
 }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/local/database/settings/SettingsConstants.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/local/database/settings/SettingsConstants.kt
@@ -27,6 +27,7 @@ object SettingsConstants {
     val KEY_FONT_SCALE = stringPreferencesKey("font_scale")
     val KEY_APP_LANGUAGE = stringPreferencesKey("app_language")
     val KEY_POST_VIEW_STYLE = stringPreferencesKey("post_view_style")
+    val KEY_SELECTED_FONT_ID = stringPreferencesKey("selected_font_id")
 
     val KEY_PROFILE_VISIBILITY = stringPreferencesKey("profile_visibility")
     val KEY_CONTENT_VISIBILITY = stringPreferencesKey("content_visibility")
@@ -93,6 +94,7 @@ object SettingsConstants {
     val DEFAULT_DYNAMIC_COLOR_ENABLED = true
     val DEFAULT_FONT_SCALE = FontScale.MEDIUM
     val DEFAULT_APP_LANGUAGE = "en"
+    val DEFAULT_SELECTED_FONT_ID = "product_sans"
     val DEFAULT_PROFILE_VISIBILITY = ProfileVisibility.PUBLIC
     val DEFAULT_CONTENT_VISIBILITY = ContentVisibility.EVERYONE
     val DEFAULT_GROUP_PRIVACY = GroupPrivacy.EVERYONE

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/SettingsRepository.kt
@@ -37,7 +37,7 @@ interface SettingsRepository {
 
     val appearanceSettings: Flow<AppearanceSettings>
 
-
+    val selectedFontId: Flow<String>
 
     suspend fun setThemeMode(mode: ThemeMode)
 
@@ -53,7 +53,7 @@ interface SettingsRepository {
 
     suspend fun setPostViewStyle(style: com.synapse.social.studioasinc.ui.settings.PostViewStyle)
 
-
+    suspend fun setSelectedFontId(id: String)
 
     val language: Flow<String>
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/SettingsRepositoryImpl.kt
@@ -73,6 +73,8 @@ class SettingsRepositoryImpl private constructor(
 
     override val appearanceSettings: Flow<AppearanceSettings> = settingsDataStore.appearanceSettings
 
+    override val selectedFontId: Flow<String> = settingsDataStore.selectedFontId
+
     override suspend fun setThemeMode(mode: ThemeMode) {
         settingsDataStore.setThemeMode(mode)
     }
@@ -87,6 +89,10 @@ class SettingsRepositoryImpl private constructor(
 
     override suspend fun setPostViewStyle(style: com.synapse.social.studioasinc.ui.settings.PostViewStyle) {
         settingsDataStore.setPostViewStyle(style)
+    }
+
+    override suspend fun setSelectedFontId(id: String) {
+        settingsDataStore.setSelectedFontId(id)
     }
 
     override val language: Flow<String> = settingsDataStore.language

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/AppearanceScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/AppearanceScreen.kt
@@ -22,9 +22,11 @@ import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 fun AppearanceScreen(
     viewModel: AppearanceViewModel,
     onNavigateBack: () -> Unit,
-    onNavigateToChatCustomization: () -> Unit = {}
+    onNavigateToChatCustomization: () -> Unit = {},
+    onNavigateToFont: () -> Unit = {}
 ) {
     val appearanceSettings by viewModel.appearanceSettings.collectAsState()
+    val selectedFontDisplayName by viewModel.selectedFontDisplayName.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val error by viewModel.error.collectAsState()
 
@@ -72,6 +74,18 @@ fun AppearanceScreen(
                 .padding(horizontal = SettingsSpacing.screenPadding),
             verticalArrangement = Arrangement.spacedBy(SettingsSpacing.sectionSpacing)
         ) {
+
+            item {
+                SettingsSection(title = stringResource(R.string.settings_font_title)) {
+                    SettingsNavigationItem(
+                        title = stringResource(R.string.settings_font_title),
+                        subtitle = selectedFontDisplayName,
+                        imageVector = null,
+                        onClick = onNavigateToFont,
+                        enabled = !isLoading
+                    )
+                }
+            }
 
             item {
                 SettingsSection(title = stringResource(R.string.settings_theme_t)) {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/AppearanceViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/AppearanceViewModel.kt
@@ -25,6 +25,9 @@ class AppearanceViewModel(
     private val _appearanceSettings = MutableStateFlow(AppearanceSettings())
     val appearanceSettings: StateFlow<AppearanceSettings> = _appearanceSettings.asStateFlow()
 
+    private val _selectedFontDisplayName = MutableStateFlow("Product Sans")
+    val selectedFontDisplayName: StateFlow<String> = _selectedFontDisplayName.asStateFlow()
+
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
@@ -57,6 +60,19 @@ class AppearanceViewModel(
             } catch (e: Exception) {
                 android.util.Log.e("AppearanceViewModel", "Failed to load appearance settings", e)
                 _error.value = "Failed to load appearance settings"
+            }
+        }
+        viewModelScope.launch {
+            try {
+                settingsRepository.selectedFontId.collect { id ->
+                    _selectedFontDisplayName.value = if (id.startsWith("custom_")) {
+                        id.removePrefix("custom_")
+                    } else {
+                        "Product Sans"
+                    }
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             }
         }
     }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/FontScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/FontScreen.kt
@@ -1,0 +1,161 @@
+package com.synapse.social.studioasinc.ui.settings
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.synapse.social.studioasinc.R
+import com.synapse.social.studioasinc.feature.shared.theme.Spacing
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun FontScreen(
+    viewModel: FontViewModel,
+    onNavigateBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+
+    val filePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        uri?.let { viewModel.importFont(it) }
+    }
+
+    Scaffold(
+        topBar = {
+            LargeTopAppBar(
+                title = { Text(stringResource(R.string.settings_font_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back)
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+                colors = TopAppBarDefaults.largeTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    scrolledContainerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { filePickerLauncher.launch("*/*") },
+                shape = FloatingActionButtonDefaults.shape,
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Add,
+                    contentDescription = stringResource(R.string.settings_font_add)
+                )
+            }
+        },
+        snackbarHost = {
+            if (uiState.error != null) {
+                Snackbar(
+                    modifier = Modifier.padding(Spacing.Medium),
+                    action = {
+                        TextButton(onClick = { viewModel.clearError() }) {
+                            Text(stringResource(R.string.action_dismiss))
+                        }
+                    }
+                ) {
+                    Text(uiState.error ?: "")
+                }
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .nestedScroll(scrollBehavior.nestedScrollConnection)
+                .padding(paddingValues)
+                .padding(horizontal = SettingsSpacing.screenPadding),
+            verticalArrangement = Arrangement.spacedBy(Spacing.SmallMedium)
+        ) {
+            items(uiState.fonts, key = { it.id }) { font ->
+                FontCard(
+                    font = font,
+                    isSelected = font.id == uiState.selectedFontId,
+                    onClick = { viewModel.selectFont(font.id) }
+                )
+            }
+        }
+
+        if (uiState.isImporting) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+    }
+}
+
+@Composable
+private fun FontCard(
+    font: AppFontFamily,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = MaterialTheme.shapes.medium,
+        color = if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.2f) else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        border = if (isSelected) androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.primary) else null
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(Spacing.Medium)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = font.displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = font.fontFamily,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
+                Text(
+                    text = stringResource(R.string.settings_font_preview),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontFamily = font.fontFamily,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (isSelected) {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = stringResource(R.string.settings_font_selected),
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/FontViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/FontViewModel.kt
@@ -1,0 +1,138 @@
+package com.synapse.social.studioasinc.ui.settings
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toFile
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.synapse.social.studioasinc.data.repository.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import javax.inject.Inject
+
+data class FontUiState(
+    val fonts: List<AppFontFamily> = emptyList(),
+    val selectedFontId: String = "product_sans",
+    val isImporting: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class FontViewModel @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(FontUiState())
+    val uiState: StateFlow<FontUiState> = _uiState.asStateFlow()
+
+    init {
+        loadFonts()
+        viewModelScope.launch {
+            settingsRepository.selectedFontId.collect { selectedFontId ->
+                _uiState.update { it.copy(selectedFontId = selectedFontId) }
+            }
+        }
+    }
+
+    private fun loadFonts() {
+        val builtInFont = AppFontFamily(
+            id = "product_sans",
+            displayName = "Product Sans",
+            isBuiltIn = true,
+            fontFamily = com.synapse.social.studioasinc.feature.shared.theme.ProductSans
+        )
+
+        val customFonts = mutableListOf<AppFontFamily>()
+        val fontsDir = File(context.filesDir, "fonts")
+        if (fontsDir.exists()) {
+            fontsDir.listFiles()?.forEach { file ->
+                if (file.extension.equals("ttf", ignoreCase = true) || file.extension.equals("otf", ignoreCase = true)) {
+                    val fontFamily = try {
+                        androidx.compose.ui.text.font.FontFamily(androidx.compose.ui.text.font.Font(file))
+                    } catch (e: Exception) {
+                        null
+                    }
+                    customFonts.add(
+                        AppFontFamily(
+                            id = "custom_${file.name}",
+                            displayName = file.nameWithoutExtension,
+                            isBuiltIn = false,
+                            fontFamily = fontFamily
+                        )
+                    )
+                }
+            }
+        }
+
+        val allFonts = listOf(builtInFont) + customFonts
+        _uiState.update { it.copy(fonts = allFonts) }
+    }
+
+    fun selectFont(id: String) {
+        viewModelScope.launch {
+            try {
+                settingsRepository.setSelectedFontId(id)
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = "Failed to select font") }
+            }
+        }
+    }
+
+    fun importFont(uri: Uri) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isImporting = true, error = null) }
+            try {
+                val fontsDir = File(context.filesDir, "fonts")
+                if (!fontsDir.exists()) {
+                    fontsDir.mkdirs()
+                }
+
+                val fileName = getFileName(uri) ?: "imported_font_${System.currentTimeMillis()}.ttf"
+                val destFile = File(fontsDir, fileName)
+
+                context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                    destFile.outputStream().use { outputStream ->
+                        inputStream.copyTo(outputStream)
+                    }
+                }
+
+                loadFonts()
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = "Failed to import font: ${e.message}") }
+            } finally {
+                _uiState.update { it.copy(isImporting = false) }
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    private fun getFileName(uri: Uri): String? {
+        var result: String? = null
+        if (uri.scheme == "content") {
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val index = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                    if (index != -1) {
+                        result = cursor.getString(index)
+                    }
+                }
+            }
+        }
+        if (result == null) {
+            result = uri.path?.let { File(it).name }
+        }
+        return result
+    }
+}

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/SettingsDestination.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/SettingsDestination.kt
@@ -96,6 +96,8 @@ sealed class SettingsDestination(val route: String) {
 
     object Flags : SettingsDestination(ROUTE_FLAGS)
 
+    object Font : SettingsDestination(ROUTE_FONT)
+
     companion object {
 
         const val ROUTE_HUB = "settings_hub"
@@ -124,6 +126,7 @@ sealed class SettingsDestination(val route: String) {
         const val ROUTE_CHAT_SETTINGS = "settings_chat_settings"
         const val ROUTE_CHAT_FOLDERS = "settings_chat_folders"
         const val ROUTE_FLAGS = "settings_flags"
+        const val ROUTE_FONT = "settings_font"
 
 
 
@@ -152,7 +155,8 @@ sealed class SettingsDestination(val route: String) {
             BlockedContacts,
             ChatSettings,
             ChatFolders,
-            Flags
+            Flags,
+            Font
         )
 
 
@@ -183,6 +187,7 @@ sealed class SettingsDestination(val route: String) {
             ROUTE_CHAT_SETTINGS -> ChatSettings
             ROUTE_CHAT_FOLDERS -> ChatFolders
             ROUTE_FLAGS -> Flags
+            ROUTE_FONT -> Font
             else -> null
         }
     }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/SettingsModels.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/SettingsModels.kt
@@ -115,13 +115,21 @@ data class AppearanceSettings(
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val dynamicColorEnabled: Boolean = true,
     val fontScale: FontScale = FontScale.MEDIUM,
-    val postViewStyle: PostViewStyle = PostViewStyle.SWIPE
+    val postViewStyle: PostViewStyle = PostViewStyle.SWIPE,
+    val selectedFontId: String = "product_sans"
 )
 
 enum class PostViewStyle {
     SWIPE, GRID;
     fun displayName(): String = name.lowercase().replaceFirstChar { it.uppercase() }
 }
+
+data class AppFontFamily(
+    val id: String,
+    val displayName: String,
+    val isBuiltIn: Boolean,
+    val fontFamily: androidx.compose.ui.text.font.FontFamily? = null
+)
 
 data class PrivacySettings(
     val profileVisibility: ProfileVisibility = ProfileVisibility.PUBLIC,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/SettingsNavHost.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/SettingsNavHost.kt
@@ -140,6 +140,19 @@ fun SettingsNavHost(
                 },
                 onNavigateToChatCustomization = {
 
+                },
+                onNavigateToFont = {
+                    navController.navigate(SettingsDestination.ROUTE_FONT)
+                }
+            )
+        }
+
+        composable(route = SettingsDestination.ROUTE_FONT) {
+            val viewModel: FontViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel()
+            FontScreen(
+                viewModel = viewModel,
+                onNavigateBack = {
+                    navController.popBackStack()
                 }
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1718,4 +1718,9 @@ Please explain the following message from %3$s in detail, considering the contex
     <string name="share_reel">Share Reel</string>
     <string name="seen_by_count">Seen by %1$d</string>
     <string name="default_avatar_letter">A</string>
+    <string name="settings_font_title">Font</string>
+    <string name="settings_font_add">Add Font</string>
+    <string name="settings_font_preview">The quick brown fox jumps over the lazy dog</string>
+    <string name="settings_font_selected">Selected</string>
+    <string name="action_back">Back</string>
 </resources>


### PR DESCRIPTION
Adds a new Font Screen under Settings > Appearance to allow users to select from built-in fonts and import custom fonts from their device storage. Persistence is handled via `SettingsDataStore`.

---
*PR created automatically by Jules for task [17394827041346271644](https://jules.google.com/task/17394827041346271644) started by @TheRealAshik*