### PR TITLE
✨ feat: Add Messenger-style chat intro header

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatInitializationDelegate.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatInitializationDelegate.kt
@@ -35,6 +35,7 @@ class ChatInitializationDelegate(
     private val _error: MutableStateFlow<String?>,
     private val _participantProfile: MutableStateFlow<User?>,
     private val _isE2EEReady: MutableStateFlow<Boolean>,
+    private val _isGroupChat: MutableStateFlow<Boolean>,
     private val _onlyAdminsCanMessage: MutableStateFlow<Boolean>,
     private val _isCurrentUserAdmin: MutableStateFlow<Boolean>,
     private val _isParticipantActive: MutableStateFlow<Boolean>,
@@ -87,6 +88,7 @@ class ChatInitializationDelegate(
             }
 
             getChatInfoUseCase(actualChatId).onSuccess { chatDto ->
+                _isGroupChat.value = chatDto?.isGroup == true
                 if (chatDto?.isGroup == true) {
                     _onlyAdminsCanMessage.value = chatDto.onlyAdminsCanMessage
                     getGroupMembersUseCase(actualChatId).onSuccess { members ->

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
@@ -71,6 +71,9 @@ class ChatViewModel @Inject constructor(
     private val _isParticipantActive = MutableStateFlow(false)
     val isParticipantActive: StateFlow<Boolean> = _isParticipantActive.asStateFlow()
 
+    private val _isGroupChat = MutableStateFlow(false)
+    val isGroupChat: StateFlow<Boolean> = _isGroupChat.asStateFlow()
+
     private val _isCurrentUserAdmin = MutableStateFlow(false)
     val isCurrentUserAdmin: StateFlow<Boolean> = _isCurrentUserAdmin.asStateFlow()
 
@@ -267,6 +270,7 @@ class ChatViewModel @Inject constructor(
         _error = _error,
         _participantProfile = _participantProfile,
         _isE2EEReady = _isE2EEReady,
+        _isGroupChat = _isGroupChat,
         _onlyAdminsCanMessage = _onlyAdminsCanMessage,
         _isCurrentUserAdmin = _isCurrentUserAdmin,
         _isParticipantActive = _isParticipantActive,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatIntroHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatIntroHeader.kt
@@ -98,3 +98,4 @@ fun ChatIntroHeader(
 }
 
 // Trigger CI
+// Trigger CI 2

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatIntroHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatIntroHeader.kt
@@ -1,0 +1,93 @@
+package com.synapse.social.studioasinc.feature.inbox.inbox.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.synapse.social.studioasinc.R
+import com.synapse.social.studioasinc.feature.shared.theme.Spacing
+import com.synapse.social.studioasinc.shared.domain.model.User
+
+@Composable
+fun ChatIntroHeader(
+    participantProfile: User?,
+    avatarUrl: String?,
+    onViewProfile: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = Spacing.ExtraLarge, horizontal = Spacing.Medium),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        AsyncImage(
+            model = avatarUrl,
+            contentDescription = stringResource(id = R.string.cd_profile_picture),
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(96.dp)
+                .clip(RoundedCornerShape(20.dp))
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.Medium))
+
+        Text(
+            text = participantProfile?.displayName ?: participantProfile?.name ?: participantProfile?.username ?: "",
+            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
+
+        val subtitle = if (!participantProfile?.bio.isNullOrBlank()) {
+            participantProfile?.bio ?: ""
+        } else {
+            val username = participantProfile?.username ?: ""
+            val followers = participantProfile?.followersCount ?: 0
+            "@$username · $followers followers"
+        }
+
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.MediumLarge))
+
+        OutlinedButton(onClick = onViewProfile) {
+            Text(text = stringResource(id = R.string.view_profile))
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.Large))
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Lock,
+                contentDescription = null,
+                modifier = Modifier.size(14.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.width(Spacing.ExtraSmall))
+            Text(
+                text = stringResource(id = R.string.messages_are_end_to_end_encrypted),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatIntroHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatIntroHeader.kt
@@ -21,6 +21,7 @@ import com.synapse.social.studioasinc.shared.domain.model.User
 @Composable
 fun ChatIntroHeader(
     participantProfile: User?,
+    initialParticipantName: String?,
     avatarUrl: String?,
     onViewProfile: () -> Unit,
     modifier: Modifier = Modifier
@@ -43,7 +44,7 @@ fun ChatIntroHeader(
         Spacer(modifier = Modifier.height(Spacing.Medium))
 
         Text(
-            text = participantProfile?.displayName ?: participantProfile?.name ?: participantProfile?.username ?: "",
+            text = participantProfile?.displayName ?: participantProfile?.name ?: participantProfile?.username ?: initialParticipantName ?: "",
             style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
             color = MaterialTheme.colorScheme.onSurface
         )
@@ -53,9 +54,13 @@ fun ChatIntroHeader(
         val subtitle = if (!participantProfile?.bio.isNullOrBlank()) {
             participantProfile?.bio ?: ""
         } else {
-            val username = participantProfile?.username ?: ""
+            val username = participantProfile?.username ?: initialParticipantName?.replace(" ", "")?.lowercase() ?: ""
             val followers = participantProfile?.followersCount ?: 0
-            "@$username · $followers followers"
+            if (username.isNotEmpty()) {
+                "@$username · $followers followers"
+            } else {
+                "$followers followers"
+            }
         }
 
         Text(

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatIntroHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatIntroHeader.kt
@@ -96,3 +96,5 @@ fun ChatIntroHeader(
         }
     }
 }
+
+// Trigger CI

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
@@ -33,12 +33,14 @@ internal fun ChatMessageList(
     chatAvatarDisabled: Boolean,
     participantProfile: com.synapse.social.studioasinc.shared.domain.model.User?,
     participantAvatarUrl: String?,
+    isGroupChat: Boolean,
     listState: LazyListState,
     onToggleSelection: (String) -> Unit,
     onSwipeToReply: (Message) -> Unit,
     onLongClick: (Message) -> Unit,
     onReactionSelected: (String, SharedReactionType) -> Unit,
     onShowReactionPicker: (Message) -> Unit,
+    onNavigateToProfile: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val messagesMap = remember(messages) {
@@ -108,6 +110,16 @@ internal fun ChatMessageList(
                         senderAvatarUrl = participantAvatarUrl
                     )
                 }
+            }
+        }
+
+        if (!isGroupChat) {
+            item(key = "chat_intro_header") {
+                com.synapse.social.studioasinc.feature.inbox.inbox.components.ChatIntroHeader(
+                    participantProfile = participantProfile,
+                    avatarUrl = participantAvatarUrl,
+                    onViewProfile = { participantProfile?.uid?.let(onNavigateToProfile) }
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
@@ -32,6 +32,7 @@ internal fun ChatMessageList(
     chatThemePreset: ChatThemePreset,
     chatAvatarDisabled: Boolean,
     participantProfile: com.synapse.social.studioasinc.shared.domain.model.User?,
+    initialParticipantName: String?,
     participantAvatarUrl: String?,
     isGroupChat: Boolean,
     listState: LazyListState,
@@ -117,6 +118,7 @@ internal fun ChatMessageList(
             item(key = "chat_intro_header") {
                 com.synapse.social.studioasinc.feature.inbox.inbox.components.ChatIntroHeader(
                     participantProfile = participantProfile,
+                    initialParticipantName = initialParticipantName,
                     avatarUrl = participantAvatarUrl,
                     onViewProfile = { participantProfile?.uid?.let(onNavigateToProfile) }
                 )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
@@ -157,6 +157,7 @@ fun ChatScreen(
     onNavigateBack: () -> Unit,
     onNavigateToGroupInfo: (String, String) -> Unit = { _, _ -> },
     onNavigateToUserMoreOptions: (String) -> Unit = {},
+    onNavigateToProfile: (String) -> Unit = {},
     viewModel: ChatViewModel = hiltViewModel()
 ) {
     // Initialize the ViewModel with the chat ID
@@ -195,6 +196,7 @@ fun ChatScreen(
     val selectedMessageIds by viewModel.selectedMessageIds.collectAsState()
     val replyingToMessage by viewModel.replyingToMessage.collectAsState()
     val toastMessage by viewModel.toastMessage.collectAsState()
+    val isGroupChat by viewModel.isGroupChat.collectAsState()
 
     val currentUserId = viewModel.currentUserId ?: ""
 
@@ -342,12 +344,14 @@ fun ChatScreen(
                         chatAvatarDisabled = chatAvatarDisabled,
                         participantProfile = participantProfile,
                         participantAvatarUrl = participantAvatarUrl,
+                        isGroupChat = isGroupChat,
                         listState = listState,
                         onToggleSelection = { viewModel.toggleMessageSelection(it) },
                         onSwipeToReply = { viewModel.setReplyingToMessage(it) },
                         onLongClick = { selectedMessageForMenu = it },
                         onReactionSelected = { id, reaction -> viewModel.toggleMessageReaction(id, reaction) },
-                        onShowReactionPicker = { selectedMessageForMenu = it }
+                        onShowReactionPicker = { selectedMessageForMenu = it },
+                        onNavigateToProfile = onNavigateToProfile
                     )
 
                     // Context Menu and Reactions for messages

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
@@ -260,10 +260,18 @@ fun ChatScreen(
     }
 
     // Auto-scroll to bottom when new messages arrive
+    var previousMessagesSize by remember { mutableStateOf(0) }
     LaunchedEffect(messages.size) {
         if (messages.isNotEmpty()) {
-            listState.animateScrollToItem(0)
+            if (previousMessagesSize == 0) {
+                // Initial load: Snap to bottom instantly without animation to prevent scroll jump
+                listState.scrollToItem(0)
+            } else if (messages.size > previousMessagesSize) {
+                // New message arrived: Animate scroll
+                listState.animateScrollToItem(0)
+            }
         }
+        previousMessagesSize = messages.size
     }
 
     Scaffold(
@@ -343,6 +351,7 @@ fun ChatScreen(
                         chatThemePreset = chatThemePreset,
                         chatAvatarDisabled = chatAvatarDisabled,
                         participantProfile = participantProfile,
+                        initialParticipantName = initialParticipantName,
                         participantAvatarUrl = participantAvatarUrl,
                         isGroupChat = isGroupChat,
                         listState = listState,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/navigation/AppNavigation.kt
@@ -152,6 +152,9 @@ fun NavGraphBuilder.inboxGraph(navController: NavHostController) {
                     },
                     onNavigateToUserMoreOptions = { userId ->
                         navController.navigate(AppDestination.UserMoreOptions(userId))
+                    },
+                    onNavigateToProfile = { userId ->
+                        navController.navigate(AppDestination.Profile(userId))
                     }
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1338,6 +1338,8 @@ Please explain the following message from %3$s in detail, considering the contex
     <string name="ok">OK</string>
 
     <!-- Added strings for no hardcoded values -->
+    <string name="view_profile">View Profile</string>
+    <string name="messages_are_end_to_end_encrypted">Messages are end-to-end encrypted</string>
     <string name="share_profile">Share Profile</string>
     <string name="view_as">View As...</string>
     <string name="new_message">New Message</string>


### PR DESCRIPTION
- Created `ChatIntroHeader.kt` to match the target UI prototype (avatar, name, bio/dynamic subtitle, View Profile CTA, E2E notice).
- Modified `ChatViewModel` and `ChatInitializationDelegate` to expose `isGroupChat`.
- Modified `ChatMessageList` to render `ChatIntroHeader` when `isGroupChat` is false.
- Modified `ChatScreen` and `AppNavigation` to thread through the navigation callback for viewing a profile.

---
*PR created automatically by Jules for task [16435823170701911826](https://jules.google.com/task/16435823170701911826) started by @TheRealAshik*