### PR TITLE
Fix notifications deserialization and user click bugs

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/notifications/NotificationItem.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/notifications/NotificationItem.kt
@@ -41,6 +41,7 @@ sealed interface UiText {
 data class UiNotification(
     val id: String,
     val type: String,
+    val actorId: String?,
     val actorName: UiText,
     val actorAvatar: String?,
     val message: UiText,
@@ -70,7 +71,7 @@ fun NotificationItem(
             imageUrl = notification.actorAvatar,
             contentDescription = "Avatar",
             size = Sizes.IconGiant,
-            onClick = { onUserClick(actorNameString) }
+            onClick = { onUserClick(notification.actorId ?: "") }
         )
 
         Spacer(modifier = Modifier.width(Spacing.Medium))
@@ -81,7 +82,7 @@ fun NotificationItem(
                     text = actorNameString,
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Bold,
-                    modifier = Modifier.clickable(onClick = { onUserClick(actorNameString) })
+                    modifier = Modifier.clickable(onClick = { onUserClick(notification.actorId ?: "") })
                 )
                 Spacer(modifier = Modifier.width(Spacing.ExtraSmall))
                 Text(

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/notifications/NotificationsViewModel.kt
@@ -105,6 +105,7 @@ class NotificationsViewModel @Inject constructor(
         return UiNotification(
             id = notification.id,
             type = notification.type,
+            actorId = notification.actorId,
             actorName = actorName,
             actorAvatar = notification.actorAvatar,
             message = message,

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/mapper/NotificationMapper.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/mapper/NotificationMapper.kt
@@ -11,12 +11,13 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 
 fun NotificationDto.toDomain(): Notification {
-    val messageBody = body["en"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
+    val messageBody = body?.get("en")?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
     val messageType = if (messageBody != null) NotificationMessageType.CUSTOM else NotificationMessageType.FALLBACK
 
     return Notification(
         id = id,
         type = type,
+        actorId = senderId,
         actorName = actor?.displayName,
         actorAvatar = actor?.avatar,
         message = messageBody,

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/model/NotificationDtos.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/model/NotificationDtos.kt
@@ -12,7 +12,7 @@ data class NotificationDto(
     @SerialName("sender_id") val senderId: String? = null,
     @SerialName("type") val type: String,
     @SerialName("title") val title: JsonObject,
-    @SerialName("body") val body: JsonObject,
+    @SerialName("body") val body: JsonObject? = null,
     @SerialName("data") val data: JsonObject? = null,
     @SerialName("priority") val priority: Int = 2,
     @SerialName("delivery_status") val deliveryStatus: String? = "pending",

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/model/Notification.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/model/Notification.kt
@@ -14,6 +14,7 @@ enum class NotificationMessageType {
 data class Notification(
     val id: String,
     val type: String,
+    val actorId: String?,
     val actorName: String?,
     val actorAvatar: String?,
     val message: String?,


### PR DESCRIPTION
Resolves the issue where the notifications screen shows nothing due to JSON deserialization failures on the `body` field. Also fixes the bug where clicking on a user's avatar or name passes the display name instead of the user ID.

---
*PR created automatically by Jules for task [16268351698707003319](https://jules.google.com/task/16268351698707003319) started by @TheRealAshik*