### PR TITLE
🐛 fix: Clear cached messages and conversations on sign out

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/settings/SettingsActivity.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
 import javax.inject.Inject
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.synapse.social.studioasinc.shared.data.local.database.CachedConversationDao
+import com.synapse.social.studioasinc.shared.data.local.database.CachedMessageDao
 import com.synapse.social.studioasinc.shared.domain.repository.AuthRepository
 import com.synapse.social.studioasinc.AuthActivity
 import com.synapse.social.studioasinc.feature.profile.ProfileEditActivity
@@ -32,6 +34,12 @@ class SettingsActivity : ComponentActivity() {
 
     @Inject
     lateinit var authRepository: AuthRepository
+
+    @Inject
+    lateinit var cachedConversationDao: CachedConversationDao
+
+    @Inject
+    lateinit var cachedMessageDao: CachedMessageDao
 
     override fun onCreate(savedInstanceState: Bundle?) {
         android.util.Log.d("SettingsActivity", "onCreate called")
@@ -94,6 +102,8 @@ class SettingsActivity : ComponentActivity() {
 
     private fun performLogout() {
         lifecycleScope.launch {
+            cachedConversationDao.deleteAll()
+            cachedMessageDao.deleteAll()
             authRepository.signOut()
             startActivity(Intent(this@SettingsActivity, AuthActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK


### PR DESCRIPTION
**Title:** `🐞 fix: Clear cached messages and conversations on sign out`

### 🐞 Bug Description
- **Current Behavior:** Chat messages and conversations remain visible in the cache when a user logs out and switches to a different account.
- **Expected Behavior:** Logging out should wipe the local cache, preventing the next user from seeing the previous user's messages and conversations.
- **Steps to Reproduce:**
  1. Log into an account and open the chat screen.
  2. Go to Settings and Log Out.
  3. Log into a different account.
  4. Notice the previous user's chat messages are briefly (or fully) visible due to the local cache not being cleared.

### 🔧 Fix Approach
- **How it was fixed:** Updated `SettingsActivity.kt` to inject `CachedConversationDao` and `CachedMessageDao` via Hilt. During the `performLogout` flow, it now calls `deleteAll()` on both DAOs before performing the sign-out request to `authRepository`.
- **Potential Side Effects:** None anticipated. Clearing local cache on logout is standard behavior for proper multi-account isolation. The data remains safely stored remotely and will be re-fetched for the next logged-in user.

### 🧪 Verification
- [X] Bug is reproducible without this change
- [X] Bug is fixed with this change
- [X] Regression testing performed
- [ ] Tests added/updated

### ✅ Build Status
- [X] Passed
- [ ] Failed
- [ ] N/A

### 🔗 References
- Fixes #<issue-number>

---
*PR created automatically by Jules for task [11760274166966647885](https://jules.google.com/task/11760274166966647885) started by @TheRealAshik*