### PR TITLE
fix: clear local chat cache and viewmodel state on sign out to prevent cross-account data leaks

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/auth/presentation/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/auth/presentation/viewmodel/AuthViewModel.kt
@@ -12,6 +12,7 @@ import com.synapse.social.studioasinc.shared.domain.model.PasswordStrength
 import com.synapse.social.studioasinc.shared.domain.model.ValidationResult
 import com.synapse.social.studioasinc.core.config.Constants
 import com.synapse.social.studioasinc.shared.domain.usecase.auth.*
+import com.synapse.social.studioasinc.shared.domain.model.auth.AuthSessionStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 
 import kotlinx.coroutines.Job
@@ -38,6 +39,8 @@ class AuthViewModel @Inject constructor(
     private val calculatePasswordStrengthUseCase: CalculatePasswordStrengthUseCase,
     private val checkUsernameAvailabilityUseCase: CheckUsernameAvailabilityUseCase,
     private val signInUseCase: SignInUseCase,
+    private val chatRepository: com.synapse.social.studioasinc.shared.domain.repository.ChatRepository,
+    private val authRepository: com.synapse.social.studioasinc.shared.domain.repository.AuthRepository,
     private val signUpUseCase: SignUpUseCase,
     private val sendPasswordResetUseCase: SendPasswordResetUseCase,
     private val resetPasswordUseCase: ResetPasswordUseCase,
@@ -304,6 +307,21 @@ class AuthViewModel @Inject constructor(
             )
         }
     }
+
+    init {
+        observeAuthStatus()
+    }
+
+    private fun observeAuthStatus() {
+        viewModelScope.launch {
+            authRepository.sessionStatus.collect { status ->
+                if (status == AuthSessionStatus.NOT_AUTHENTICATED) {
+                    chatRepository.clearLocalCache()
+                }
+            }
+        }
+    }
+
 
     fun onBackToSignInClick() {
         _uiState.value = AuthUiState.SignIn()

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/InboxViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/InboxViewModel.kt
@@ -14,6 +14,7 @@ import com.synapse.social.studioasinc.shared.domain.usecase.chat.InitializeE2EUs
 import com.synapse.social.studioasinc.shared.domain.usecase.chat.MarkMessagesAsDeliveredUseCase
 import com.synapse.social.studioasinc.shared.domain.usecase.chat.SubscribeToInboxUpdatesUseCase
 import com.synapse.social.studioasinc.shared.util.TimestampFormatter
+import com.synapse.social.studioasinc.shared.domain.model.auth.AuthSessionStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -29,7 +30,8 @@ class InboxViewModel @Inject constructor(
     private val markMessagesAsDeliveredUseCase: MarkMessagesAsDeliveredUseCase,
     private val chatLockManager: com.synapse.social.studioasinc.core.util.ChatLockManager,
     private val settingsRepository: SettingsRepository,
-    private val chatRepository: com.synapse.social.studioasinc.shared.domain.repository.ChatRepository
+    private val chatRepository: com.synapse.social.studioasinc.shared.domain.repository.ChatRepository,
+    private val authRepository: com.synapse.social.studioasinc.shared.domain.repository.AuthRepository
 ) : ViewModel() {
 
     private val _currentUserProfile = MutableStateFlow<User?>(null)
@@ -84,6 +86,7 @@ class InboxViewModel @Inject constructor(
     }
 
     init {
+        observeAuthStatus()
         viewModelScope.launch {
             initializeE2EUseCase().onFailure { e ->
                 _error.value = "Failed to initialize E2EE: ${e.message}"
@@ -113,6 +116,17 @@ class InboxViewModel @Inject constructor(
             }.onFailure { e ->
                 _error.value = "Failed to load conversations: ${e.message}"
                 _isLoading.value = false
+            }
+        }
+    }
+
+    private fun observeAuthStatus() {
+        viewModelScope.launch {
+            authRepository.sessionStatus.collect { status ->
+                if (status == AuthSessionStatus.NOT_AUTHENTICATED) {
+                    _conversations.value = emptyList()
+                    _currentUserProfile.value = null
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseChatRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseChatRepository.kt
@@ -459,6 +459,11 @@ class SupabaseChatRepository(
         Result.failure(e)
     }
 
+    override suspend fun clearLocalCache() {
+        cachedConversationDao?.deleteAll()
+        cachedMessageDao?.deleteAll()
+    }
+
     override suspend fun getReactionsForMessages(messages: List<Message>): List<Message> = try {
         val currentUserId = getCurrentUserId()
         val allReactions = reactionDataSource.getReactionsForMessages(messages.map { it.id })

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/repository/ChatRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/repository/ChatRepository.kt
@@ -45,6 +45,7 @@ interface ChatRepository {
     suspend fun toggleMessageReaction(messageId: String, emoji: String): Result<Unit>
     suspend fun getReactionsForMessage(messageId: String): Result<List<MessageReaction>>
     suspend fun getReactionsForMessages(messages: List<Message>): List<Message>
+    suspend fun clearLocalCache()
     fun subscribeToMessageReactions(): Flow<MessageReaction>
 
 }


### PR DESCRIPTION
Fixes a critical data leak where the previous account's messages could appear in the Inbox after switching accounts.

This issue occurred because local state (`_conversations` and `_currentUserProfile` in `InboxViewModel`) and local databases (`CachedConversationDao` and `CachedMessageDao` via `ChatRepository`) were not being cleared when the authentication status changed.

Changes:
1. `ChatRepository` now defines and implements `clearLocalCache()` which truncates the local SQLDelight tables tracking messages and conversations.
2. `AuthViewModel` watches the `sessionStatus` from the `AuthRepository`. When it switches to `NOT_AUTHENTICATED`, it executes `chatRepository.clearLocalCache()`.
3. `InboxViewModel` also observes the `sessionStatus`. Upon sign out (`NOT_AUTHENTICATED`), it immediately resets the `_conversations` cache and `_currentUserProfile` back to empty states so the next login session loads cleanly from network.
4. (The nav graph already issues a `popUpTo` the auth state on logout which cleans up old VM instances).

---
*PR created automatically by Jules for task [7580145660206940236](https://jules.google.com/task/7580145660206940236) started by @TheRealAshik*