### PR TITLE
Create pure Kotlin design system tokens in shared module

### DIFF
--- a/desktop/src/jvmMain/kotlin/com/synapse/social/studioasinc/desktop/theme/SynapseTheme.kt
+++ b/desktop/src/jvmMain/kotlin/com/synapse/social/studioasinc/desktop/theme/SynapseTheme.kt
@@ -3,10 +3,53 @@ package com.synapse.social.studioasinc.desktop.theme
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.synapse.social.studioasinc.shared.theme.SynapseColorScheme
+import com.synapse.social.studioasinc.shared.theme.SynapseTheme as SharedTheme
 
-// Basic fallback colors since we can't easily access the Android ones without a shared UI module
-private val LightColorScheme = lightColorScheme()
-private val DarkColorScheme = darkColorScheme()
+private fun SynapseColorScheme.toComposeColorScheme(): ColorScheme {
+    return ColorScheme(
+        primary = Color(this.primary),
+        onPrimary = Color(this.onPrimary),
+        primaryContainer = Color(this.primaryContainer),
+        onPrimaryContainer = Color(this.onPrimaryContainer),
+        secondary = Color(this.secondary),
+        onSecondary = Color(this.onSecondary),
+        secondaryContainer = Color(this.secondaryContainer),
+        onSecondaryContainer = Color(this.onSecondaryContainer),
+        tertiary = Color(this.tertiary),
+        onTertiary = Color(this.onTertiary),
+        tertiaryContainer = Color(this.tertiaryContainer),
+        onTertiaryContainer = Color(this.onTertiaryContainer),
+        error = Color(this.error),
+        onError = Color(this.onError),
+        errorContainer = Color(this.errorContainer),
+        onErrorContainer = Color(this.onErrorContainer),
+        background = Color(this.background),
+        onBackground = Color(this.onBackground),
+        surface = Color(this.surface),
+        onSurface = Color(this.onSurface),
+        surfaceVariant = Color(this.surfaceVariant),
+        onSurfaceVariant = Color(this.onSurfaceVariant),
+        outline = Color(this.outline),
+        outlineVariant = Color(this.outlineVariant),
+        scrim = Color(this.scrim),
+        inverseSurface = Color(this.inverseSurface),
+        inverseOnSurface = Color(this.inverseOnSurface),
+        inversePrimary = Color(this.inversePrimary),
+        surfaceTint = Color(this.surfaceTint),
+        surfaceContainer = Color(this.surfaceContainer),
+        surfaceContainerLow = Color(this.surfaceContainerLow),
+        surfaceContainerHigh = Color(this.surfaceContainerHigh),
+        surfaceContainerHighest = Color(this.surfaceContainerHighest),
+        surfaceContainerLowest = Color(this.surface), // Fallback
+        surfaceDim = Color(this.surface), // Fallback
+        surfaceBright = Color(this.surface) // Fallback
+    )
+}
+
+private val LightColorScheme = SharedTheme.colors.Light.toComposeColorScheme()
+private val DarkColorScheme = SharedTheme.colors.Dark.toComposeColorScheme()
 
 @Composable
 fun SynapseTheme(

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/theme/SynapseColors.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/theme/SynapseColors.kt
@@ -1,0 +1,151 @@
+package com.synapse.social.studioasinc.shared.theme
+
+data class SynapseColorScheme(
+    val primary: Long,
+    val onPrimary: Long,
+    val primaryContainer: Long,
+    val onPrimaryContainer: Long,
+    val secondary: Long,
+    val onSecondary: Long,
+    val secondaryContainer: Long,
+    val onSecondaryContainer: Long,
+    val tertiary: Long,
+    val onTertiary: Long,
+    val tertiaryContainer: Long,
+    val onTertiaryContainer: Long,
+    val error: Long,
+    val onError: Long,
+    val errorContainer: Long,
+    val onErrorContainer: Long,
+    val background: Long,
+    val onBackground: Long,
+    val surface: Long,
+    val onSurface: Long,
+    val surfaceVariant: Long,
+    val onSurfaceVariant: Long,
+    val outline: Long,
+    val outlineVariant: Long,
+    val scrim: Long,
+    val inverseSurface: Long,
+    val inverseOnSurface: Long,
+    val inversePrimary: Long,
+    val surfaceTint: Long,
+    val surfaceContainer: Long,
+    val surfaceContainerLow: Long,
+    val surfaceContainerHigh: Long,
+    val surfaceContainerHighest: Long
+)
+
+object SynapseColors {
+    val Blue = 0xFF1976D2
+    val DarkBlue = 0xFF00497D
+    val LightBlue = 0xFFBBDEFB
+
+    val StatusOnline = 0xFF4CAF50
+    val StatusRead = 0xFF4FC3F7
+    val StatusOffline = 0xFF9E9E9E
+
+    val ForestBubbleBackground = 0xFFE8F5E9
+    val ForestBubbleText = 0xFF1B5E20
+    val SunsetBubbleBackground = 0xFFFBE9E7
+    val SunsetBubbleText = 0xFFBF360C
+    val SunsetAccent = 0xFFFF5722
+
+    val InteractionIconDefault = 0xFF657786
+    val InteractionLikeActive = 0xFFE0245E
+    val InteractionRepostActive = 0xFF17BF63
+
+    val AccentOrange = 0xFFFFA500
+    val AccentBlue = 0xFF2196F3
+    val AccentYellow = 0xFFFFC107
+
+    val Gray200 = 0xFFE0E0E0
+    val Gray300 = 0xFFBDBDBD
+    val Gray500 = 0xFF9E9E9E
+    val Gray700 = 0xFF616161
+    val Gray900 = 0xFF212121
+
+    val ChatPresetColor1 = 0xFFE8F5E9
+    val ChatPresetColor2 = 0xFFFBE9E7
+    val ChatPresetColor3 = 0xFF1B5E20
+    val ChatPresetColor4 = 0xFFBF360C
+    val ChatPresetColor5 = 0xFFFF5722
+    val ChatPresetColor6 = 0xFF9E9E9E
+    val ChatPresetColor7 = 0xFFE0E0E0
+
+    val StoryColorOrange = 0xFFFF9800
+    val StoryColorGreen = 0xFF4CAF50
+    val StoryColorPurple = 0xFF9C27B0
+
+    val Light = SynapseColorScheme(
+        primary = 0xFF6750A4,
+        onPrimary = 0xFFFFFFFF,
+        primaryContainer = 0xFFEADDFF,
+        onPrimaryContainer = 0xFF21005D,
+        secondary = 0xFF625B71,
+        onSecondary = 0xFFFFFFFF,
+        secondaryContainer = 0xFFE8DEF8,
+        onSecondaryContainer = 0xFF1D192B,
+        tertiary = 0xFF7D5260,
+        onTertiary = 0xFFFFFFFF,
+        tertiaryContainer = 0xFFFFD8E4,
+        onTertiaryContainer = 0xFF31111D,
+        error = 0xFFB3261E,
+        onError = 0xFFFFFFFF,
+        errorContainer = 0xFFF9DEDC,
+        onErrorContainer = 0xFF410E0B,
+        background = 0xFFFFFBFE,
+        onBackground = 0xFF1C1B1F,
+        surface = 0xFFFFFBFE,
+        onSurface = 0xFF1C1B1F,
+        surfaceVariant = 0xFFE7E0EC,
+        onSurfaceVariant = 0xFF49454F,
+        outline = 0xFF79747E,
+        outlineVariant = 0xFFCAC4D0,
+        scrim = 0xFF000000,
+        inverseSurface = 0xFF313033,
+        inverseOnSurface = 0xFFF4EFF4,
+        inversePrimary = 0xFFD0BCFF,
+        surfaceTint = 0xFF6750A4,
+        surfaceContainer = 0xFFF3EDF7,
+        surfaceContainerLow = 0xFFF7F2FA,
+        surfaceContainerHigh = 0xFFECE6F0,
+        surfaceContainerHighest = 0xFFE6E0E9
+    )
+
+    val Dark = SynapseColorScheme(
+        primary = 0xFFD0BCFF,
+        onPrimary = 0xFF381E72,
+        primaryContainer = 0xFF4F378B,
+        onPrimaryContainer = 0xFFEADDFF,
+        secondary = 0xFFCCC2DC,
+        onSecondary = 0xFF332D41,
+        secondaryContainer = 0xFF4A4458,
+        onSecondaryContainer = 0xFFE8DEF8,
+        tertiary = 0xFFEFB8C8,
+        onTertiary = 0xFF492532,
+        tertiaryContainer = 0xFF633B48,
+        onTertiaryContainer = 0xFFFFD8E4,
+        error = 0xFFF2B8B5,
+        onError = 0xFF601410,
+        errorContainer = 0xFF8C1D18,
+        onErrorContainer = 0xFFF9DEDC,
+        background = 0xFF1C1B1F,
+        onBackground = 0xFFE6E1E5,
+        surface = 0xFF1C1B1F,
+        onSurface = 0xFFE6E1E5,
+        surfaceVariant = 0xFF2B2930,
+        onSurfaceVariant = 0xFFCAC4D0,
+        outline = 0xFF938F99,
+        outlineVariant = 0xFF49454F,
+        scrim = 0xFF000000,
+        inverseSurface = 0xFFE6E1E5,
+        inverseOnSurface = 0xFF313033,
+        inversePrimary = 0xFF6750A4,
+        surfaceTint = 0xFFD0BCFF,
+        surfaceContainer = 0xFF211F26,
+        surfaceContainerLow = 0xFF1D1B20,
+        surfaceContainerHigh = 0xFF2B2930,
+        surfaceContainerHighest = 0xFF36343B
+    )
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/theme/SynapseSpacing.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/theme/SynapseSpacing.kt
@@ -1,0 +1,112 @@
+package com.synapse.social.studioasinc.shared.theme
+
+object SynapseSpacing {
+    const val None = 0f
+    const val Tiny = 2f
+    const val ExtraSmall = 4f
+    const val ExtraSmallMedium = 6f
+    const val Small = 8f
+    const val SmallPlus = 10f
+    const val SmallMedium = 12f
+    const val Medium = 16f
+    const val MediumLarge = 20f
+    const val Large = 24f
+    const val ExtraLarge = 32f
+    const val Huge = 48f
+    const val ButtonHeight = 40f
+    const val NavBarHeight = 60f
+}
+
+object SynapseSizes {
+    const val IconSmall = 12f
+    const val IconSemiSmall = 14f
+    const val IconSemiMedium = 16f
+    const val IconMedium = 18f
+    const val IconDefault = 20f
+    const val IconLarge = 24f
+    const val IconExtraLarge = 28f
+    const val IconHuge = 32f
+    const val IconMassive = 40f
+    const val IconGiant = 48f
+
+    const val AvatarTiny = 28f
+    const val AvatarSmall = 36f
+    const val AvatarMedium = 40f
+    const val AvatarDefault = 48f
+    const val AvatarLarge = 56f
+    const val AvatarExtraLarge = 80f
+    const val AvatarHuge = 110f
+
+    const val BorderThin = 1f
+    const val BorderHairline = 0.5f
+    const val BorderDefault = 2f
+    const val BorderSelected = 3f
+
+    const val CornerSmall = 4f
+    const val CornerMedium = 8f
+    const val CornerDefault = 12f
+    const val CornerLarge = 16f
+    const val CornerExtraLarge = 24f
+    const val CornerMassive = 28f
+    const val CornerSharp = 2f
+
+    const val HeightSmall = 24f
+    const val HeightButtonSmall = 28f
+    const val HeightMedium = 40f
+    const val HeightDefault = 56f
+    const val HeightLarge = 80f
+    const val Height100 = 100f
+    const val Height120 = 120f
+    const val HeightPreview = 300f
+    const val HeightStoryTray = 180f
+    const val HeightMediaSingle = 600f
+    const val HeightMediaGrid2 = 400f
+    const val HeightMediaGrid3Top = 350f
+    const val HeightMediaGridSmall = 150f
+    const val HeightMediaGridMedium = 200f
+    const val HeightMediaGridLarge = 250f
+    const val HeightSheetContent = 500f
+    const val HeightExtraLarge = 200f
+
+    const val HeightTiny = 14f
+    const val HeightMassive = 250f
+    const val WidthLarge = 80f
+    const val WidthExtraLarge = 100f
+    const val WidthMassive = 110f
+
+    const val ShimmerTextSmall = 14f
+    const val ShimmerTextMedium = 28f
+    const val ShimmerWidthSmall = 60f
+    const val ShimmerWidthSmallMedium = 80f
+    const val ShimmerWidthMedium = 100f
+    const val ShimmerWidthLarge = 120f
+    const val ShimmerWidthExtraLarge = 150f
+
+    const val AvatarHugeOffset = 60f
+    const val AvatarHugeHalfOffset = 55f
+    const val CommentIndent = 68f
+
+    const val SendButton = 44f
+    const val SendButtonCompact = 36f
+    const val InputButtonCompact = 40f
+    const val BubbleMaxWidth = 280f
+    const val ChatMaxWidth = 240f
+    const val StatusDot = 10f
+
+    const val AvatarSemiLarge = 64f
+    const val AvatarProfile = 96f
+    const val AvatarLargeProfile = 120f
+    const val HeightCard = 140f
+    const val HeightBanner = 100f
+    const val MediaPreviewSmall = 160f
+    const val HeightChip = 32f
+    const val EmptyStateIcon = 120f
+    const val EmptyStateIconSmall = 100f
+    const val LogoSize = 85f
+    const val QRCodeSize = 250f
+    const val HeartSize = 100f
+
+    const val MaxGridHeight = 2000f
+    const val AvatarBorder = 4f
+    const val ProfileImageOffset = -48f
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/theme/SynapseTheme.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/theme/SynapseTheme.kt
@@ -1,8 +1,8 @@
 package com.synapse.social.studioasinc.shared.theme
 
 object SynapseTheme {
-    const val RoyalBlue: Long = 0xFF4169E1
-    const val SpacingSmall: Int = 8
-    const val SpacingMedium: Int = 16
-    const val SpacingLarge: Int = 24
+    val colors = SynapseColors
+    val typography = SynapseTypography
+    val spacing = SynapseSpacing
+    val sizes = SynapseSizes
 }

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/theme/SynapseTypography.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/theme/SynapseTypography.kt
@@ -1,0 +1,106 @@
+package com.synapse.social.studioasinc.shared.theme
+
+data class SynapseTextStyle(
+    val fontSize: Float,
+    val lineHeight: Float,
+    val letterSpacing: Float,
+    val fontWeight: Int
+)
+
+object SynapseFontWeights {
+    const val Normal = 400
+    const val Bold = 700
+}
+
+object SynapseTypography {
+    val displayLarge = SynapseTextStyle(
+        fontSize = 57f,
+        lineHeight = 64f,
+        letterSpacing = -0.25f,
+        fontWeight = SynapseFontWeights.Normal
+    )
+    val displayMedium = SynapseTextStyle(
+        fontSize = 45f,
+        lineHeight = 52f,
+        letterSpacing = 0f,
+        fontWeight = SynapseFontWeights.Normal
+    )
+    val displaySmall = SynapseTextStyle(
+        fontSize = 36f,
+        lineHeight = 44f,
+        letterSpacing = 0f,
+        fontWeight = SynapseFontWeights.Normal
+    )
+    val headlineLarge = SynapseTextStyle(
+        fontSize = 32f,
+        lineHeight = 40f,
+        letterSpacing = 0f,
+        fontWeight = SynapseFontWeights.Normal
+    )
+    val headlineMedium = SynapseTextStyle(
+        fontSize = 28f,
+        lineHeight = 36f,
+        letterSpacing = 0f,
+        fontWeight = SynapseFontWeights.Normal
+    )
+    val headlineSmall = SynapseTextStyle(
+        fontSize = 24f,
+        lineHeight = 32f,
+        letterSpacing = 0f,
+        fontWeight = SynapseFontWeights.Normal
+    )
+    val titleLarge = SynapseTextStyle(
+        fontSize = 22f,
+        lineHeight = 28f,
+        letterSpacing = 0f,
+        fontWeight = SynapseFontWeights.Normal
+    )
+    val titleMedium = SynapseTextStyle(
+        fontSize = 16f,
+        lineHeight = 24f,
+        letterSpacing = 0.15f,
+        fontWeight = SynapseFontWeights.Bold
+    )
+    val titleSmall = SynapseTextStyle(
+        fontSize = 14f,
+        lineHeight = 20f,
+        letterSpacing = 0.1f,
+        fontWeight = SynapseFontWeights.Bold
+    )
+    val bodyLarge = SynapseTextStyle(
+        fontSize = 16f,
+        lineHeight = 24f,
+        letterSpacing = 0.5f,
+        fontWeight = SynapseFontWeights.Normal
+    )
+    val bodyMedium = SynapseTextStyle(
+        fontSize = 14f,
+        lineHeight = 20f,
+        letterSpacing = 0.25f,
+        fontWeight = SynapseFontWeights.Normal
+    )
+    val bodySmall = SynapseTextStyle(
+        fontSize = 12f,
+        lineHeight = 16f,
+        letterSpacing = 0.4f,
+        fontWeight = SynapseFontWeights.Normal
+    )
+    val labelLarge = SynapseTextStyle(
+        fontSize = 14f,
+        lineHeight = 20f,
+        letterSpacing = 0.1f,
+        fontWeight = SynapseFontWeights.Bold
+    )
+    val labelMedium = SynapseTextStyle(
+        fontSize = 12f,
+        lineHeight = 16f,
+        letterSpacing = 0.5f,
+        fontWeight = SynapseFontWeights.Bold
+    )
+    val labelSmall = SynapseTextStyle(
+        fontSize = 11f,
+        lineHeight = 16f,
+        letterSpacing = 0.5f,
+        fontWeight = SynapseFontWeights.Bold
+    )
+}


### PR DESCRIPTION
This PR introduces the foundational structure for a unified design system within the shared Kotlin Multiplatform module (`:shared`), paving the way to deprecate hardcoded, module-specific theme duplications.

Using primitive data types (`Long`, `Float`) avoids tight coupling to Jetpack/JetBrains Compose dependencies within the shared domain, ensuring complete portability across native iOS/SwiftUI, Android Compose, JVM Desktop, and Wasm/JS web modules.

The Desktop UI module was updated as a proof-of-concept to consume and bridge these shared raw color tokens into Compose `ColorScheme` instances successfully.

---
*PR created automatically by Jules for task [7063353650093803280](https://jules.google.com/task/7063353650093803280) started by @TheRealAshik*