### PR TITLE
feat(ios): Implement local Analytics and CrashReporting fallback

### DIFF
--- a/iosApp/iosApp/Core/Services/AnalyticsService.swift
+++ b/iosApp/iosApp/Core/Services/AnalyticsService.swift
@@ -8,13 +8,57 @@ protocol AnalyticsService {
 
 class DefaultAnalyticsService: AnalyticsService {
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.synapse.social", category: "Analytics")
+    private let fileURL: URL
+    private let queue = DispatchQueue(label: "com.synapse.social.analytics", qos: .background)
+
+    init() {
+        let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        fileURL = documentsDirectory.appendingPathComponent("analytics_events.json")
+
+        if !FileManager.default.fileExists(atPath: fileURL.path) {
+            try? "[]".write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+    }
 
     func trackEvent(_ name: String, parameters: [String: Any]? = nil) {
-        // Placeholder for real analytics integration (e.g. Firebase, Mixpanel)
         logger.debug("📊 [Analytics] Event: \(name), Params: \(parameters ?? [:], privacy: .private)")
+
+        queue.async {
+            let event: [String: Any] = [
+                "timestamp": ISO8601DateFormatter().string(from: Date()),
+                "name": name,
+                "parameters": parameters ?? [:]
+            ]
+
+            self.appendEventToFile(event)
+        }
     }
 
     func setUserProperty(_ value: String, forName name: String) {
         logger.debug("📊 [Analytics] User Property: \(name) = \(value, privacy: .private)")
+
+        queue.async {
+            let event: [String: Any] = [
+                "timestamp": ISO8601DateFormatter().string(from: Date()),
+                "type": "user_property",
+                "name": name,
+                "value": value
+            ]
+
+            self.appendEventToFile(event)
+        }
+    }
+
+    private func appendEventToFile(_ event: [String: Any]) {
+        do {
+            let data = try Data(contentsOf: fileURL)
+            var events = try JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] ?? []
+            events.append(event)
+
+            let newData = try JSONSerialization.data(withJSONObject: events, options: [.prettyPrinted])
+            try newData.write(to: fileURL, options: .atomic)
+        } catch {
+            logger.error("Failed to write analytics event: \(error.localizedDescription)")
+        }
     }
 }

--- a/iosApp/iosApp/Core/Services/CrashReportingService.swift
+++ b/iosApp/iosApp/Core/Services/CrashReportingService.swift
@@ -2,6 +2,7 @@ import Foundation
 import OSLog
 
 protocol CrashReportingService {
+    func start()
     func recordError(_ error: Error)
     func setUserId(_ id: String)
     func log(_ message: String)
@@ -9,17 +10,96 @@ protocol CrashReportingService {
 
 class DefaultCrashReportingService: CrashReportingService {
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.synapse.social", category: "CrashReporting")
+    private let crashFileURL: URL
+    private let queue = DispatchQueue(label: "com.synapse.social.crashreporting", qos: .background)
+    private var userId: String?
+
+    init() {
+        let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        crashFileURL = documentsDirectory.appendingPathComponent("crash_reports.json")
+
+        if !FileManager.default.fileExists(atPath: crashFileURL.path) {
+            try? "[]".write(to: crashFileURL, atomically: true, encoding: .utf8)
+        }
+    }
+
+    func start() {
+        setupCrashHandler()
+        logger.debug("💥 [CrashReporting] Started local crash reporter")
+    }
+
+    private func setupCrashHandler() {
+        NSSetUncaughtExceptionHandler { exception in
+            let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            let crashFileURL = documentsDirectory.appendingPathComponent("crash_reports.json")
+
+            let crashReport: [String: Any] = [
+                "timestamp": ISO8601DateFormatter().string(from: Date()),
+                "name": exception.name.rawValue,
+                "reason": exception.reason ?? "Unknown",
+                "callStackSymbols": exception.callStackSymbols
+            ]
+
+            // Note: Since this is happening during a crash, we must write synchronously and safely
+            do {
+                var events: [[String: Any]] = []
+                if let data = try? Data(contentsOf: crashFileURL),
+                   let existingEvents = try? JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] {
+                    events = existingEvents
+                }
+
+                events.append(crashReport)
+
+                if let newData = try? JSONSerialization.data(withJSONObject: events, options: [.prettyPrinted]) {
+                    try? newData.write(to: crashFileURL, options: .atomic)
+                }
+            }
+        }
+    }
 
     func recordError(_ error: Error) {
-        // Placeholder for real crash reporting (e.g. Crashlytics)
-        logger.error("💥 [Crashlytics] Recorded Error: \(error.localizedDescription)")
+        logger.error("💥 [CrashReporting] Recorded Error: \(error.localizedDescription)")
+
+        queue.async {
+            let errorReport: [String: Any] = [
+                "timestamp": ISO8601DateFormatter().string(from: Date()),
+                "type": "error",
+                "description": error.localizedDescription,
+                "userId": self.userId ?? "unknown"
+            ]
+            self.appendReportToFile(errorReport)
+        }
     }
 
     func setUserId(_ id: String) {
-        logger.debug("💥 [Crashlytics] Set User ID: \(id)")
+        logger.debug("💥 [CrashReporting] Set User ID: \(id)")
+        queue.async {
+            self.userId = id
+        }
     }
 
     func log(_ message: String) {
-        logger.debug("💥 [Crashlytics] Log: \(message)")
+        logger.debug("💥 [CrashReporting] Log: \(message)")
+        queue.async {
+            let logEntry: [String: Any] = [
+                "timestamp": ISO8601DateFormatter().string(from: Date()),
+                "type": "log",
+                "message": message
+            ]
+            self.appendReportToFile(logEntry)
+        }
+    }
+
+    private func appendReportToFile(_ report: [String: Any]) {
+        do {
+            let data = try Data(contentsOf: crashFileURL)
+            var reports = try JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] ?? []
+            reports.append(report)
+
+            let newData = try JSONSerialization.data(withJSONObject: reports, options: [.prettyPrinted])
+            try newData.write(to: crashFileURL, options: .atomic)
+        } catch {
+            logger.error("Failed to write crash/error report: \(error.localizedDescription)")
+        }
     }
 }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -11,6 +11,7 @@ struct iOSApp: App {
         self.crashReporter = DependencyContainer.shared.crashReportingService
         self.analyticsService = DependencyContainer.shared.analyticsService
 
+        crashReporter.start()
         crashReporter.log("App Initialized")
         analyticsService.trackEvent("app_launched", parameters: nil)
     }


### PR DESCRIPTION
Implemented a functional, local fallback for iOS analytics and crash reporting since no existing third-party SDKs (e.g. Firebase) are configured.

1. `AnalyticsService` now correctly appends track events to a local `analytics_events.json` file in the Documents directory.
2. `CrashReportingService` catches uncaught exceptions utilizing `NSSetUncaughtExceptionHandler` and saves the stack trace locally in `crash_reports.json`.
3. Updated `iOSApp.swift` to instantiate the `CrashReportingService` and initialize the crash handler at application startup.

---
*PR created automatically by Jules for task [7430424281707471663](https://jules.google.com/task/7430424281707471663) started by @TheRealAshik*