### PR TITLE
feat(ios): use real auth user id and implement image upload

### DIFF
--- a/iosApp/iosApp/Profile/EditProfileView.swift
+++ b/iosApp/iosApp/Profile/EditProfileView.swift
@@ -13,11 +13,21 @@ struct EditProfileView: View {
 
     var body: some View {
         Form {
+            if let error = viewModel.generalError {
+                Section {
+                    Text(error)
+                        .foregroundColor(.red)
+                }
+            }
+
             Section {
                 HStack {
                     Spacer()
                     VStack {
-                        if let profileImage = profileImage {
+                        if viewModel.isUploading {
+                            ProgressView()
+                                .frame(width: 100, height: 100)
+                        } else if let profileImage = profileImage {
                             profileImage
                                 .resizable()
                                 .scaledToFill()
@@ -33,6 +43,12 @@ struct EditProfileView: View {
                         PhotosPicker(selection: $selectedItem, matching: .images, photoLibrary: .shared()) {
                             Text("Change Profile Photo")
                                 .foregroundColor(.blue)
+                        }
+
+                        if let error = viewModel.uploadError {
+                            Text(error)
+                                .foregroundColor(.red)
+                                .font(.caption)
                         }
                     }
                     Spacer()
@@ -61,7 +77,9 @@ struct EditProfileView: View {
             Button("Save Changes") {
                 Task {
                     await viewModel.updateProfile(displayName: displayName, bio: bio)
-                    presentationMode.wrappedValue.dismiss()
+                    if viewModel.generalError == nil {
+                        presentationMode.wrappedValue.dismiss()
+                    }
                 }
             }
         }
@@ -72,10 +90,11 @@ struct EditProfileView: View {
         }
         .onChange(of: selectedItem) { newItem in
             Task {
-                if let data = try? await newItem?.loadTransferable(type: Data.self),
-                   let uiImage = UIImage(data: data) {
-                    profileImage = Image(uiImage: uiImage)
-                    // TODO: Implement image upload to KMP StorageService
+                if let data = try? await newItem?.loadTransferable(type: Data.self) {
+                    if let uiImage = UIImage(data: data) {
+                        profileImage = Image(uiImage: uiImage)
+                    }
+                    await viewModel.uploadProfileImage(data: data)
                 }
             }
         }

--- a/iosApp/iosApp/ViewModels/ProfileViewModel.swift
+++ b/iosApp/iosApp/ViewModels/ProfileViewModel.swift
@@ -4,30 +4,96 @@ import shared
 @MainActor
 class ProfileViewModel: ObservableObject {
     @Published var user: User? = nil
+    @Published var isUploading: Bool = false
+    @Published var uploadError: String? = nil
+    @Published var generalError: String? = nil
 
     private let iosDependencies = IOSDependencies.shared
 
-    // Mock UID for demo since auth isn't wired in iOS yet
-    private let currentUid = "dummy-uid"
+    private var currentUid: String {
+        return iosDependencies.getAuthRepository().getCurrentUserId() ?? ""
+    }
 
     func loadProfile() async {
+        let uid = currentUid
+        guard !uid.isEmpty else {
+            self.generalError = "No authenticated user ID found"
+            return
+        }
+
         do {
             // Swift correctly interprets the Kotlin @Throws wrapper returning User?
-            let fetchedUser = try await iosDependencies.fetchUserProfile(uid: currentUid)
+            let fetchedUser = try await iosDependencies.fetchUserProfile(uid: uid)
             self.user = fetchedUser
-            print("Called loadProfile")
         } catch {
-            print("Error: \(error)")
+            self.generalError = "Failed to load profile: \(error.localizedDescription)"
         }
     }
 
     func updateProfile(displayName: String, bio: String) async {
+        let uid = currentUid
+        guard !uid.isEmpty else {
+            self.generalError = "No authenticated user ID found"
+            return
+        }
+
         do {
             let updates: [String: Any] = ["display_name": displayName, "bio": bio]
-            _ = try await iosDependencies.saveUserProfile(uid: currentUid, updates: updates)
+            _ = try await iosDependencies.saveUserProfile(uid: uid, updates: updates)
             await loadProfile()
         } catch {
-            print("Error: \(error)")
+            self.generalError = "Failed to update profile: \(error.localizedDescription)"
         }
+    }
+
+    func uploadProfileImage(data: Data) async {
+        let uid = currentUid
+        guard !uid.isEmpty else {
+            self.uploadError = "No authenticated user ID found"
+            return
+        }
+
+        self.isUploading = true
+        self.uploadError = nil
+
+        do {
+            // Convert to JPEG data to ensure format consistency
+            guard let image = UIImage(data: data),
+                  let jpegData = image.jpegData(compressionQuality: 0.8) else {
+                self.uploadError = "Failed to process image data"
+                self.isUploading = false
+                return
+            }
+
+            // For KMP integration we'll simulate saving to a tmp path:
+            let tempDir = FileManager.default.temporaryDirectory
+            let fileName = UUID().uuidString + ".jpg"
+            let tempUrl = tempDir.appendingPathComponent(fileName)
+
+            try jpegData.write(to: tempUrl)
+
+            let uploadUseCase = KMPHelper.sharedHelper.uploadMediaUseCase
+
+            // UploadMediaUseCase returns a Result<String> mapped natively.
+            // Since Swift unwraps Kotlin Results, it directly throws on error or returns String
+            let resultUrl = try await uploadUseCase.invoke(
+                filePath: tempUrl.path,
+                mediaType: .photo,
+                bucketName: SupabaseClient.shared.BUCKET_USER_AVATARS,
+                onProgress: { _ in }
+            )
+
+            let updates: [String: Any] = ["avatar_url": resultUrl]
+            _ = try await iosDependencies.saveUserProfile(uid: uid, updates: updates)
+            await loadProfile()
+
+            // Cleanup tmp file
+            try? FileManager.default.removeItem(at: tempUrl)
+
+        } catch {
+            self.uploadError = error.localizedDescription
+        }
+
+        self.isUploading = false
     }
 }

--- a/shared/src/iosMain/kotlin/com/synapse/social/studioasinc/shared/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/synapse/social/studioasinc/shared/di/KoinHelper.kt
@@ -10,6 +10,7 @@ import com.synapse.social.studioasinc.shared.domain.usecase.blocking.UnblockUser
 import com.synapse.social.studioasinc.shared.domain.usecase.blocking.GetBlockedUsersUseCase
 import com.synapse.social.studioasinc.shared.domain.model.User
 import com.synapse.social.studioasinc.shared.domain.model.BlockedUser
+import com.synapse.social.studioasinc.shared.domain.repository.AuthRepository
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -21,6 +22,7 @@ object IOSDependencies : KoinComponent {
     fun getUserPreferencesRepository() = UserPreferencesRepositoryImpl(SupabaseClient.client)
 
     // Inject StorageRepository from Koin
+    fun getAuthRepository(): AuthRepository = getKoin().get()
     fun getStorageRepository(): com.synapse.social.studioasinc.shared.domain.repository.StorageRepository = getKoin().get()
 
     // Create use cases on demand


### PR DESCRIPTION
Replaced dummy user IDs with KMP AuthRepository `getCurrentUserId`. Implemented profile image uploading by writing Swift Data to a temporary path and passing it to the shared KMP `UploadMediaUseCase`. Exposed AuthRepository to iOS via IOSDependencies.

---
*PR created automatically by Jules for task [15012218414552376729](https://jules.google.com/task/15012218414552376729) started by @TheRealAshik*