### PR TITLE
Fix NotificationsViewModel mapping, subscriptions, and state

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/notifications/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/notifications/NotificationsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.res.stringResource
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -17,11 +18,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import com.synapse.social.studioasinc.ui.components.ExpressivePullToRefreshIndicator
 import com.synapse.social.studioasinc.ui.home.FeedLoading
+import com.synapse.social.studioasinc.feature.auth.ui.components.ErrorCard
+
 @Composable
 fun NotificationHeader(date: String) {
     Box(
@@ -47,7 +53,21 @@ fun NotificationsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val pullToRefreshState = rememberPullToRefreshState()
-    
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_START) {
+                viewModel.startRealtime()
+            } else if (event == Lifecycle.Event.ON_STOP) {
+                viewModel.stopRealtime()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
 
     val currentOnNotificationClick by rememberUpdatedState(onNotificationClick)
     val currentOnUserClick by rememberUpdatedState(onUserClick)
@@ -65,45 +85,52 @@ fun NotificationsScreen(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        PullToRefreshBox(
-            isRefreshing = uiState.isLoading,
-            onRefresh = { viewModel.refresh() },
-            state = pullToRefreshState,
-            indicator = {
-                ExpressivePullToRefreshIndicator(
-                    state = pullToRefreshState,
-                    isRefreshing = uiState.isLoading,
-                    modifier = Modifier.align(Alignment.TopCenter)
-                )
-            }
-        ) {
-            val showLoading = uiState.isLoading && uiState.notifications.isEmpty()
-            val showEmpty = !uiState.isLoading && uiState.notifications.isEmpty()
+    Column(modifier = Modifier.fillMaxSize()) {
+        ErrorCard(
+            error = uiState.error?.asString(),
+            onDismiss = viewModel::clearError
+        )
 
-            if (showLoading) {
-                FeedLoading()
-            } else if (showEmpty) {
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text(stringResource(R.string.no_notifications), style = MaterialTheme.typography.bodyLarge)
+        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            PullToRefreshBox(
+                isRefreshing = uiState.isLoading,
+                onRefresh = { viewModel.refresh() },
+                state = pullToRefreshState,
+                indicator = {
+                    ExpressivePullToRefreshIndicator(
+                        state = pullToRefreshState,
+                        isRefreshing = uiState.isLoading,
+                        modifier = Modifier.align(Alignment.TopCenter)
+                    )
                 }
-            } else {
-                val groupedNotifications = uiState.groupedNotifications
+            ) {
+                val showLoading = uiState.isLoading && uiState.notifications.isEmpty()
+                val showEmpty = !uiState.isLoading && uiState.notifications.isEmpty()
 
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = contentPadding
-                ) {
-                    groupedNotifications.forEach { (date, notifications) ->
-                        item {
-                            NotificationHeader(date.asString())
-                        }
-                        itemsIndexed(notifications, key = { index, it -> "${it.id}_${index}" }) { index, notification ->
-                            NotificationItem(
-                                notification = notification,
-                                onNotificationClick = handleNotificationClick,
-                                onUserClick = handleUserClick
-                            )
+                if (showLoading) {
+                    FeedLoading()
+                } else if (showEmpty) {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(stringResource(R.string.no_notifications), style = MaterialTheme.typography.bodyLarge)
+                    }
+                } else {
+                    val groupedNotifications = uiState.groupedNotifications
+
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = contentPadding
+                    ) {
+                        groupedNotifications.forEach { (date, notifications) ->
+                            item {
+                                NotificationHeader(date.asString())
+                            }
+                            itemsIndexed(notifications, key = { index, it -> "${it.id}_${index}" }) { index, notification ->
+                                NotificationItem(
+                                    notification = notification,
+                                    onNotificationClick = handleNotificationClick,
+                                    onUserClick = handleUserClick
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/notifications/NotificationsViewModel.kt
@@ -30,7 +30,8 @@ data class NotificationsUiState(
     val notifications: List<UiNotification> = emptyList(),
     val isLoading: Boolean = false,
     val unreadCount: Int = 0,
-    val groupedNotifications: Map<UiText, List<UiNotification>> = emptyMap()
+    val groupedNotifications: Map<UiText, List<UiNotification>> = emptyMap(),
+    val error: UiText? = null
 )
 
 @HiltViewModel
@@ -52,7 +53,7 @@ class NotificationsViewModel @Inject constructor(
     fun loadNotifications() {
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
+            _uiState.update { it.copy(isLoading = true, error = null) }
 
             getNotificationsUseCase().collect { result ->
                 result.onSuccess { notifications ->
@@ -65,16 +66,21 @@ class NotificationsViewModel @Inject constructor(
                             groupedNotifications = uiNotifications.groupBy { formatDateHeader(it.timestamp) }
                         )
                     }
-                    subscribeToRealtime()
                 }.onFailure { error ->
                     Napier.e("Failed to load notifications: $error")
-                    _uiState.update { it.copy(isLoading = false) }
+                    val uiError = when (error) {
+                        is com.synapse.social.studioasinc.shared.domain.model.NotificationError.NetworkError -> UiText.StringResource(R.string.error_network)
+                        is com.synapse.social.studioasinc.shared.domain.model.NotificationError.Unauthorized -> UiText.StringResource(R.string.error_authentication)
+                        else -> UiText.StringResource(R.string.error_unknown)
+                    }
+                    _uiState.update { it.copy(isLoading = false, error = uiError) }
                 }
             }
         }
     }
 
-    private fun subscribeToRealtime() {
+    fun startRealtime() {
+        if (realtimeJob?.isActive == true) return
         realtimeJob?.cancel()
         realtimeJob = viewModelScope.launch {
             try {
@@ -119,6 +125,15 @@ class NotificationsViewModel @Inject constructor(
         loadNotifications()
     }
 
+    fun stopRealtime() {
+        realtimeJob?.cancel()
+        realtimeJob = null
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
     fun markAsRead(notificationId: String) {
         viewModelScope.launch {
             // Optimistic update
@@ -126,6 +141,12 @@ class NotificationsViewModel @Inject constructor(
 
             markNotificationAsReadUseCase(notificationId).onFailure { e ->
                 Napier.e("Failed to mark as read for notification $notificationId", e)
+                val uiError = when (e) {
+                    is com.synapse.social.studioasinc.shared.domain.model.NotificationError.NetworkError -> UiText.StringResource(R.string.error_network)
+                    is com.synapse.social.studioasinc.shared.domain.model.NotificationError.Unauthorized -> UiText.StringResource(R.string.error_authentication)
+                    else -> UiText.StringResource(R.string.error_unknown)
+                }
+                _uiState.update { it.copy(error = uiError) }
                 // Revert optimistic update
                 setNotificationReadState(notificationId, isRead = false)
             }


### PR DESCRIPTION
Fix NotificationsViewModel mapping, subscriptions, and state

* Added explicit explicit start/stop functionality to realtime subscriptions using viewmodel.
* Updated `NotificationsScreen` with `DisposableEffect` to manage the bindings based on the view model's lifecycle events.
* Ensure domain errors (`NotificationError`) are fully covered and mapped to `UiText.StringResource` using `NotificationsViewModel`.
* `NotificationsUiState` state now correctly tracks the error parameter.

---
*PR created automatically by Jules for task [4363446749935216406](https://jules.google.com/task/4363446749935216406) started by @TheRealAshik*