### PR TITLE
feat(desktop): wire desktop main screen to shared chat use cases

### DIFF
--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
             dependencies {
                 implementation(project(":shared"))
                 implementation("io.insert-koin:koin-core:4.1.1")
+                implementation("io.insert-koin:koin-compose:4.1.1")
                 implementation("io.github.jan-tennert.supabase:postgrest-kt:3.4.1")
                 implementation("io.github.jan-tennert.supabase:auth-kt:3.4.1")
                 implementation("io.github.jan-tennert.supabase:realtime-kt:3.4.1")

--- a/desktop/src/jvmMain/kotlin/Main.kt
+++ b/desktop/src/jvmMain/kotlin/Main.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.window.application
 import com.synapse.social.studioasinc.desktop.theme.SynapseTheme
 import com.synapse.social.studioasinc.desktop.ui.DesktopMainScreen
 import com.synapse.social.studioasinc.shared.di.storageModule
+import com.synapse.social.studioasinc.desktop.di.desktopModule
 import com.synapse.social.studioasinc.shared.core.network.SupabaseClient
 import org.koin.core.context.startKoin
 import io.github.aakira.napier.Napier
@@ -13,7 +14,7 @@ import io.github.aakira.napier.Napier
 fun main() = application {
     try {
         startKoin {
-            modules(storageModule)
+            modules(storageModule, desktopModule)
         }
 
         // Ensure Supabase is initialized

--- a/desktop/src/jvmMain/kotlin/com/synapse/social/studioasinc/desktop/di/DesktopModule.kt
+++ b/desktop/src/jvmMain/kotlin/com/synapse/social/studioasinc/desktop/di/DesktopModule.kt
@@ -1,0 +1,34 @@
+package com.synapse.social.studioasinc.desktop.di
+
+import com.synapse.social.studioasinc.desktop.ui.DesktopChatViewModel
+import com.synapse.social.studioasinc.shared.data.datasource.SupabaseChatDataSource
+import com.synapse.social.studioasinc.shared.data.repository.SupabaseChatRepository
+import com.synapse.social.studioasinc.shared.domain.repository.ChatRepository
+import com.synapse.social.studioasinc.shared.domain.usecase.chat.GetConversationsUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.chat.GetMessagesUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.chat.SendMessageUseCase
+import com.synapse.social.studioasinc.shared.core.network.SupabaseClient
+import org.koin.dsl.module
+
+val desktopModule = module {
+    single { SupabaseChatDataSource(SupabaseClient.client) }
+
+    single<ChatRepository> {
+        SupabaseChatRepository(
+            dataSource = get(),
+            client = SupabaseClient.client,
+            signalProtocolManager = null,
+            mediaUploadRepository = get(),
+            presenceRepository = null,
+            offlineActionRepository = getOrNull(),
+            cachedMessageDao = getOrNull(),
+            cachedConversationDao = getOrNull()
+        )
+    }
+
+    single { GetConversationsUseCase(get()) }
+    single { GetMessagesUseCase(get()) }
+    single { SendMessageUseCase(get(), null) }
+
+    factory { DesktopChatViewModel(get(), get(), get()) }
+}

--- a/desktop/src/jvmMain/kotlin/com/synapse/social/studioasinc/desktop/ui/DesktopChatViewModel.kt
+++ b/desktop/src/jvmMain/kotlin/com/synapse/social/studioasinc/desktop/ui/DesktopChatViewModel.kt
@@ -1,0 +1,88 @@
+package com.synapse.social.studioasinc.desktop.ui
+
+import com.synapse.social.studioasinc.shared.domain.model.chat.Conversation
+import com.synapse.social.studioasinc.shared.domain.model.chat.Message
+import com.synapse.social.studioasinc.shared.domain.usecase.chat.GetConversationsUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.chat.GetMessagesUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.chat.SendMessageUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.delay
+
+class DesktopChatViewModel(
+    private val getConversationsUseCase: GetConversationsUseCase,
+    private val getMessagesUseCase: GetMessagesUseCase,
+    private val sendMessageUseCase: SendMessageUseCase
+) {
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    private val _conversations = MutableStateFlow<List<Conversation>>(emptyList())
+    val conversations: StateFlow<List<Conversation>> = _conversations.asStateFlow()
+
+    private val _messages = MutableStateFlow<List<Message>>(emptyList())
+    val messages: StateFlow<List<Message>> = _messages.asStateFlow()
+
+    private val _selectedConversation = MutableStateFlow<Conversation?>(null)
+    val selectedConversation: StateFlow<Conversation?> = _selectedConversation.asStateFlow()
+
+    private val _isLoadingConversations = MutableStateFlow(false)
+    val isLoadingConversations: StateFlow<Boolean> = _isLoadingConversations.asStateFlow()
+
+    private val _isLoadingMessages = MutableStateFlow(false)
+    val isLoadingMessages: StateFlow<Boolean> = _isLoadingMessages.asStateFlow()
+
+    init {
+        loadConversations()
+    }
+
+    private fun loadConversations() {
+        viewModelScope.launch {
+            _isLoadingConversations.value = true
+            getConversationsUseCase().onSuccess { result ->
+                _conversations.value = result
+            }.onFailure { error ->
+                Napier.e("Failed to load conversations", error)
+            }
+            _isLoadingConversations.value = false
+        }
+    }
+
+    fun selectConversation(conversation: Conversation) {
+        _selectedConversation.value = conversation
+        loadMessages(conversation.chatId)
+    }
+
+    private fun loadMessages(chatId: String) {
+        viewModelScope.launch {
+            _isLoadingMessages.value = true
+            getMessagesUseCase(chatId = chatId).onSuccess { result ->
+                _messages.value = result
+            }.onFailure { error ->
+                Napier.e("Failed to load messages", error)
+                _messages.value = emptyList()
+            }
+            _isLoadingMessages.value = false
+        }
+    }
+
+    fun sendMessage(content: String) {
+        val chatId = _selectedConversation.value?.chatId ?: return
+        viewModelScope.launch {
+            sendMessageUseCase(
+                chatId = chatId,
+                content = content
+            ).onSuccess {
+                // Optimistically reload messages for now, or just append it if we have real-time
+                loadMessages(chatId)
+            }.onFailure { error ->
+                Napier.e("Failed to send message", error)
+            }
+        }
+    }
+}

--- a/desktop/src/jvmMain/kotlin/com/synapse/social/studioasinc/desktop/ui/DesktopMainScreen.kt
+++ b/desktop/src/jvmMain/kotlin/com/synapse/social/studioasinc/desktop/ui/DesktopMainScreen.kt
@@ -17,22 +17,19 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.synapse.social.studioasinc.desktop.model.ChatItem
-
-
+import org.koin.compose.koinInject
+import com.synapse.social.studioasinc.shared.domain.model.chat.Conversation
+import com.synapse.social.studioasinc.shared.domain.model.chat.Message
 
 @Composable
-fun DesktopMainScreen() {
-    val chats = remember {
-        listOf(
-            ChatItem("1", "Alice", "Hey, how are you?"),
-            ChatItem("2", "Bob", "See you tomorrow!"),
-            ChatItem("3", "Charlie", "Got the documents."),
-            ChatItem("4", "Diana", "Sounds good to me.")
-        )
-    }
-
-    var selectedChat by remember { mutableStateOf<ChatItem?>(null) }
+fun DesktopMainScreen(
+    viewModel: DesktopChatViewModel = koinInject()
+) {
+    val conversations by viewModel.conversations.collectAsState()
+    val messages by viewModel.messages.collectAsState()
+    val selectedConversation by viewModel.selectedConversation.collectAsState()
+    val isLoadingConversations by viewModel.isLoadingConversations.collectAsState()
+    val isLoadingMessages by viewModel.isLoadingMessages.collectAsState()
 
     Row(modifier = Modifier.fillMaxSize()) {
         // Master View (Left Sidebar)
@@ -50,13 +47,24 @@ fun DesktopMainScreen() {
                     modifier = Modifier.padding(16.dp)
                 )
                 HorizontalDivider()
-                LazyColumn {
-                    items(chats) { chat ->
-                        ChatListItem(
-                            chat = chat,
-                            isSelected = chat == selectedChat,
-                            onClick = { selectedChat = chat }
-                        )
+
+                if (isLoadingConversations) {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                } else if (conversations.isEmpty()) {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("No conversations found")
+                    }
+                } else {
+                    LazyColumn {
+                        items(conversations) { conversation ->
+                            ChatListItem(
+                                conversation = conversation,
+                                isSelected = conversation.chatId == selectedConversation?.chatId,
+                                onClick = { viewModel.selectConversation(conversation) }
+                            )
+                        }
                     }
                 }
             }
@@ -69,9 +77,14 @@ fun DesktopMainScreen() {
                 .fillMaxHeight()
                 .background(MaterialTheme.colorScheme.background)
         ) {
-            val chat = selectedChat
-            if (chat != null) {
-                ChatDetailView(chat = chat)
+            val conversation = selectedConversation
+            if (conversation != null) {
+                ChatDetailView(
+                    conversation = conversation,
+                    messages = messages,
+                    isLoading = isLoadingMessages,
+                    onSendMessage = { text -> viewModel.sendMessage(text) }
+                )
             } else {
                 Box(
                     modifier = Modifier.fillMaxSize(),
@@ -89,7 +102,7 @@ fun DesktopMainScreen() {
 }
 
 @Composable
-fun ChatListItem(chat: ChatItem, isSelected: Boolean, onClick: () -> Unit) {
+fun ChatListItem(conversation: Conversation, isSelected: Boolean, onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -109,14 +122,19 @@ fun ChatListItem(chat: ChatItem, isSelected: Boolean, onClick: () -> Unit) {
         }
         Spacer(modifier = Modifier.width(16.dp))
         Column {
-            Text(text = chat.name, fontWeight = FontWeight.Bold)
-            Text(text = chat.lastMessage, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(text = conversation.participantName, fontWeight = FontWeight.Bold)
+            Text(text = conversation.lastMessage, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }
 
 @Composable
-fun ChatDetailView(chat: ChatItem) {
+fun ChatDetailView(
+    conversation: Conversation,
+    messages: List<Message>,
+    isLoading: Boolean,
+    onSendMessage: (String) -> Unit
+) {
     var messageText by remember { mutableStateOf("") }
 
     Column(modifier = Modifier.fillMaxSize()) {
@@ -139,19 +157,36 @@ fun ChatDetailView(chat: ChatItem) {
                     Icon(Icons.Default.Person, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimary)
                 }
                 Spacer(modifier = Modifier.width(16.dp))
-                Text(text = chat.name, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                Text(text = conversation.participantName, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
             }
         }
 
-        // Chat History Placeholder
+        // Chat History
         Box(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
-                .padding(16.dp),
-            contentAlignment = Alignment.Center
+                .padding(16.dp)
         ) {
-            Text("This is the beginning of your chat history with ${chat.name}.")
+            if (isLoading) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            } else if (messages.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("This is the beginning of your chat history with ${conversation.participantName}.")
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    reverseLayout = true
+                ) {
+                    items(messages) { message ->
+                        MessageItem(message)
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
+            }
         }
 
         // Message Input
@@ -173,8 +208,10 @@ fun ChatDetailView(chat: ChatItem) {
                 Spacer(modifier = Modifier.width(8.dp))
                 IconButton(
                     onClick = {
-                        // TODO: Implement actual message sending logic here instead of just clearing the text
-                        messageText = ""
+                        if (messageText.isNotBlank()) {
+                            onSendMessage(messageText)
+                            messageText = ""
+                        }
                     },
                     enabled = messageText.isNotBlank()
                 ) {
@@ -182,5 +219,21 @@ fun ChatDetailView(chat: ChatItem) {
                 }
             }
         }
+    }
+}
+
+@Composable
+fun MessageItem(message: Message) {
+    // For simplicity, just rendering content, aligned left
+    // Real implementation would align based on sender ID (message.isFromMe(currentUserId))
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.medium,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = message.content,
+            modifier = Modifier.padding(12.dp)
+        )
     }
 }


### PR DESCRIPTION
This PR updates the Desktop implementation of Synapse to use the KMP shared use cases for Chat.

### Changes
*   Added Koin module (`DesktopModule.kt`) to instantiate `SupabaseChatDataSource` and provide `ChatRepository` along with chat-related UseCases for the desktop target.
*   Added `DesktopChatViewModel` injected via Koin to handle view state.
*   Refactored `DesktopMainScreen` to replace hardcoded data models with actual `Conversation` and `Message` models via `DesktopChatViewModel`.
*   Wired up the send message button.
*   Updated `build.gradle.kts` to include `koin-compose`.
*   Updated `Main.kt` to initialize the newly created Koin desktop module.

---
*PR created automatically by Jules for task [9348663840791140086](https://jules.google.com/task/9348663840791140086) started by @TheRealAshik*