### PR TITLE
feat: Integrate real KMP Story UseCases in iOS Story view models

### DIFF
--- a/iosApp/iosApp/Chat/Models/KMPHelper.swift
+++ b/iosApp/iosApp/Chat/Models/KMPHelper.swift
@@ -22,6 +22,9 @@ class KMPHelper {
 
     let searchPostsUseCase: shared.SearchPostsUseCase
 
+    let createStoryUseCase: shared.CreateStoryUseCase
+    let getStoriesUseCase: shared.GetStoriesUseCase
+
     let sharedImageLoader: shared.SharedImageLoader
 
     init() {
@@ -65,6 +68,10 @@ class KMPHelper {
         self.uploadMediaUseCase = shared.UploadMediaUseCase(repository: chatRepository, storageRepository: storageRepository, mediaUploadRepository: mediaUploadRepository, fileUploader: fileUploader)
 
         self.searchPostsUseCase = shared.SearchPostsUseCase(repository: shared.SearchRepositoryImpl(client: shared.SupabaseClient.shared.client))
+
+        let storyRepository = shared.SupabaseStoryRepository()
+        self.createStoryUseCase = shared.CreateStoryUseCase(repository: storyRepository)
+        self.getStoriesUseCase = shared.GetStoriesUseCase(repository: storyRepository)
 
         self.sharedImageLoader = shared.SharedImageLoader(httpClient: shared.Ktor_client_coreHttpClient())
     }

--- a/iosApp/iosApp/Stories/ViewModels/StoryCreatorViewModel.swift
+++ b/iosApp/iosApp/Stories/ViewModels/StoryCreatorViewModel.swift
@@ -3,6 +3,7 @@ import shared
 import UIKit
 import AVFoundation
 
+@MainActor
 class StoryCreatorViewModel: ObservableObject {
     @Published var mediaURL: URL? = nil
     @Published var textOverlay: String = ""
@@ -13,6 +14,9 @@ class StoryCreatorViewModel: ObservableObject {
     // Caching media resources so the view doesn't recreate them every render cycle
     @Published var cachedImage: UIImage? = nil
     var cachedPlayer: AVPlayer? = nil
+
+    private let createStoryUseCase = KMPHelper.sharedHelper.createStoryUseCase
+    private let uploadMediaUseCase = KMPHelper.sharedHelper.uploadMediaUseCase
 
     func setMedia(url: URL) {
         self.mediaURL = url
@@ -43,7 +47,7 @@ class StoryCreatorViewModel: ObservableObject {
     }
 
     func submitStory() {
-        guard let _ = mediaURL else {
+        guard let url = mediaURL else {
             self.error = "Media is required for a story."
             return
         }
@@ -51,13 +55,38 @@ class StoryCreatorViewModel: ObservableObject {
         self.isLoading = true
         self.error = nil
 
-        // Simulate interaction with KMP use case for story submission
-        // e.g., submitStoryUseCase.execute(media: mediaURL, text: textOverlay)
+        let isVideo = url.pathExtension.lowercased() == "mov" || url.pathExtension.lowercased() == "mp4"
+        let mediaType = isVideo ? shared.MediaType.video : shared.MediaType.photo
+        let mediaTypeString = isVideo ? "video" : "photo"
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            self.isLoading = false
-            self.isStoryPosted = true
-            self.clearMedia()
+        Task {
+            do {
+                // 1. Upload Media
+                let result = try await uploadMediaUseCase.invoke(
+                    filePath: url.path,
+                    mediaType: mediaType,
+                    bucketName: "stories",
+                    onProgress: { _ in }
+                )
+
+                // Kotlin's Result automatically unboxes in Swift
+                let uploadedUrl = result as! String
+
+                // 2. Save Story Record
+                try await createStoryUseCase.invoke(
+                    mediaUrl: uploadedUrl,
+                    mediaType: mediaTypeString,
+                    textOverlay: self.textOverlay.isEmpty ? nil : self.textOverlay
+                )
+
+                self.isLoading = false
+                self.isStoryPosted = true
+                self.clearMedia()
+
+            } catch {
+                self.error = error.localizedDescription
+                self.isLoading = false
+            }
         }
     }
 

--- a/iosApp/iosApp/Stories/ViewModels/StoryViewerViewModel.swift
+++ b/iosApp/iosApp/Stories/ViewModels/StoryViewerViewModel.swift
@@ -3,25 +3,26 @@ import shared
 
 // Mock data model for iOS viewing
 struct StoryItem: Identifiable {
-    let id = UUID()
+    let id: String
     let mediaURL: URL
     let textOverlay: String?
-    let type: MediaType // Requires shared.MediaType or mapped
+    let type: StoryItemType
 }
 
 // Temporary mapping until shared module is fully integrated
-enum MediaType {
+enum StoryItemType {
     case image
     case video
 }
 
+@MainActor
 class StoryViewerViewModel: ObservableObject {
     @Published var stories: [StoryItem] = []
     @Published var currentIndex: Int = 0
     @Published var isLoading: Bool = true
+    @Published var error: String? = nil
 
-    // Simulating fetching stories from KMP use case
-    // let getStoriesUseCase: GetStoriesUseCase
+    private let getStoriesUseCase = KMPHelper.sharedHelper.getStoriesUseCase
 
     init() {
         fetchStories()
@@ -29,17 +30,27 @@ class StoryViewerViewModel: ObservableObject {
 
     func fetchStories() {
         self.isLoading = true
+        self.error = nil
 
-        // Simulating network delay and response
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            // Mock Data
-            if let sampleImageURL = URL(string: "https://via.placeholder.com/800x1200.png?text=Sample+Story+Image") {
-                 self.stories = [
-                    StoryItem(mediaURL: sampleImageURL, textOverlay: "Hello World!", type: .image),
-                    StoryItem(mediaURL: sampleImageURL, textOverlay: "Next Story", type: .image)
-                 ]
+        Task {
+            do {
+                let domainStories = try await getStoriesUseCase.invoke()
+
+                self.stories = domainStories.compactMap { story in
+                    guard let urlString = story.getEffectiveMediaUrl(), let url = URL(string: urlString) else { return nil }
+                    let type: StoryItemType = story.mediaType == .video ? .video : .image
+                    return StoryItem(
+                        id: story.id ?? UUID().uuidString,
+                        mediaURL: url,
+                        textOverlay: story.content,
+                        type: type
+                    )
+                }
+                self.isLoading = false
+            } catch {
+                self.error = error.localizedDescription
+                self.isLoading = false
             }
-            self.isLoading = false
         }
     }
 

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,33 @@
+<<<<<<< SEARCH
+    let searchPostsUseCase: shared.SearchPostsUseCase
+
+    let sharedImageLoader: shared.SharedImageLoader
+
+    init() {
+=======
+    let searchPostsUseCase: shared.SearchPostsUseCase
+
+    let createStoryUseCase: shared.CreateStoryUseCase
+    let getStoriesUseCase: shared.GetStoriesUseCase
+
+    let sharedImageLoader: shared.SharedImageLoader
+
+    init() {
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+        self.searchPostsUseCase = shared.SearchPostsUseCase(repository: shared.SearchRepositoryImpl(client: shared.SupabaseClient.shared.client))
+
+        self.sharedImageLoader = shared.SharedImageLoader(httpClient: shared.Ktor_client_coreHttpClient())
+    }
+}
+=======
+        self.searchPostsUseCase = shared.SearchPostsUseCase(repository: shared.SearchRepositoryImpl(client: shared.SupabaseClient.shared.client))
+
+        let storyRepository = shared.SupabaseStoryRepository()
+        self.createStoryUseCase = shared.CreateStoryUseCase(repository: storyRepository)
+        self.getStoriesUseCase = shared.GetStoriesUseCase(repository: storyRepository)
+
+        self.sharedImageLoader = shared.SharedImageLoader(httpClient: shared.Ktor_client_coreHttpClient())
+    }
+}
+>>>>>>> REPLACE

--- a/patch2.diff
+++ b/patch2.diff
@@ -1,0 +1,27 @@
+<<<<<<< SEARCH
+                    if currentStory.type == .image {
+                        AsyncImage(url: currentStory.mediaURL) { image in
+                            image
+                                .resizable()
+                                .scaledToFit()
+                        } placeholder: {
+                            Color.gray
+                        }
+                    } else {
+                        // Implement Video Player logic similar to Creator if needed
+                         Color.gray.overlay(Text("Video Unsupported Mock"))
+                    }
+=======
+                    if currentStory.type == .image {
+                        AsyncImage(url: currentStory.mediaURL) { image in
+                            image
+                                .resizable()
+                                .scaledToFit()
+                        } placeholder: {
+                            Color.gray
+                        }
+                    } else {
+                        // Implement Video Player logic similar to Creator if needed
+                         Color.gray.overlay(Text("Video Unsupported Mock"))
+                    }
+>>>>>>> REPLACE

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/model/StoryDto.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/model/StoryDto.kt
@@ -1,0 +1,80 @@
+package com.synapse.social.studioasinc.shared.data.model
+
+import com.synapse.social.studioasinc.shared.domain.model.Story
+import com.synapse.social.studioasinc.shared.domain.model.StoryMediaType
+import com.synapse.social.studioasinc.shared.domain.model.StoryPrivacy
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StoryDto(
+    val id: String? = null,
+    @SerialName("user_id")
+    val userId: String,
+    @SerialName("media_url")
+    val mediaUrl: String? = null,
+    @SerialName("media_type")
+    val mediaType: String? = null,
+    val content: String? = null,
+    val duration: Int? = null,
+    @SerialName("duration_hours")
+    val durationHours: Int? = null,
+    @SerialName("privacy_setting")
+    val privacy: String? = null,
+    @SerialName("views_count")
+    val viewCount: Int? = null,
+    @SerialName("is_active")
+    val isActive: Boolean? = null,
+    @SerialName("thumbnail_url")
+    val thumbnailUrl: String? = null,
+    @SerialName("media_width")
+    val mediaWidth: Int? = null,
+    @SerialName("media_height")
+    val mediaHeight: Int? = null,
+    @SerialName("media_duration_seconds")
+    val mediaDurationSeconds: Int? = null,
+    @SerialName("file_size_bytes")
+    val fileSizeBytes: Long? = null,
+    @SerialName("reactions_count")
+    val reactionsCount: Int? = null,
+    @SerialName("replies_count")
+    val repliesCount: Int? = null,
+    @SerialName("is_reported")
+    val isReported: Boolean? = null,
+    @SerialName("moderation_status")
+    val moderationStatus: String? = null,
+    @SerialName("created_at")
+    val createdAt: String? = null,
+    @SerialName("expires_at")
+    val expiresAt: String? = null
+)
+
+fun StoryDto.toDomain(): Story {
+    return Story(
+        id = id,
+        userId = userId,
+        mediaUrl = mediaUrl,
+        mediaType = mediaType?.let { type ->
+            StoryMediaType.entries.find { it.name.equals(type, ignoreCase = true) }
+        },
+        content = content,
+        duration = duration,
+        durationHours = durationHours,
+        privacy = privacy?.let { p ->
+            StoryPrivacy.entries.find { it.name.equals(p, ignoreCase = true) }
+        },
+        viewCount = viewCount,
+        isActive = isActive,
+        thumbnailUrl = thumbnailUrl,
+        mediaWidth = mediaWidth,
+        mediaHeight = mediaHeight,
+        mediaDurationSeconds = mediaDurationSeconds,
+        fileSizeBytes = fileSizeBytes,
+        reactionsCount = reactionsCount,
+        repliesCount = repliesCount,
+        isReported = isReported,
+        moderationStatus = moderationStatus,
+        createdAt = createdAt,
+        expiresAt = expiresAt
+    )
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseStoryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseStoryRepository.kt
@@ -1,0 +1,54 @@
+package com.synapse.social.studioasinc.shared.data.repository
+
+import com.synapse.social.studioasinc.shared.domain.model.Story
+import com.synapse.social.studioasinc.shared.data.model.StoryDto
+import com.synapse.social.studioasinc.shared.data.model.toDomain
+import com.synapse.social.studioasinc.shared.domain.repository.StoryRepository
+import com.synapse.social.studioasinc.shared.core.network.SupabaseClient
+import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Order
+import io.github.aakira.napier.Napier
+import kotlinx.datetime.Clock
+
+class SupabaseStoryRepository : StoryRepository {
+    private val client = SupabaseClient.client
+    private val TAG = "SupabaseStoryRepository"
+
+    override suspend fun getStories(): List<Story> {
+        return try {
+            val storiesDto = client.from("stories")
+                .select() {
+                    order(column = "created_at", order = Order.DESCENDING)
+                }.decodeList<StoryDto>()
+
+            storiesDto.map { it.toDomain() }
+        } catch (e: Exception) {
+            Napier.e("Failed to fetch stories", e, tag = TAG)
+            throw e
+        }
+    }
+
+    override suspend fun createStory(
+        mediaUrl: String,
+        mediaType: String,
+        textOverlay: String?
+    ) {
+        try {
+            val currentUser = client.auth.currentUserOrNull() ?: throw Exception("Not logged in")
+
+            val storyData = mapOf(
+                "user_id" to currentUser.id,
+                "media_url" to mediaUrl,
+                "media_type" to mediaType,
+                "content" to textOverlay,
+                "created_at" to Clock.System.now().toString()
+            )
+
+            client.from("stories").insert(storyData)
+        } catch (e: Exception) {
+            Napier.e("Failed to create story: ${e::class.simpleName}: ${e.message}", e, tag = TAG)
+            throw Exception("Story creation failed: ${e.message ?: e::class.simpleName}", e)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/model/Story.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/model/Story.kt
@@ -1,0 +1,77 @@
+package com.synapse.social.studioasinc.shared.domain.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class StoryMediaType {
+    @SerialName("photo")
+    PHOTO,
+    @SerialName("video")
+    VIDEO
+}
+
+@Serializable
+enum class StoryPrivacy {
+    @SerialName("all_friends")
+    ALL_FRIENDS,
+    @SerialName("public")
+    PUBLIC,
+    @SerialName("followers")
+    FOLLOWERS
+}
+
+@Serializable
+data class Story(
+    val id: String? = null,
+    @SerialName("user_id")
+    val userId: String,
+    @SerialName("media_url")
+    val mediaUrl: String? = null,
+    @SerialName("media_type")
+    val mediaType: StoryMediaType? = null,
+    val content: String? = null,
+    val duration: Int? = null,
+    @SerialName("duration_hours")
+    val durationHours: Int? = null,
+    @SerialName("privacy_setting")
+    val privacy: StoryPrivacy? = null,
+    @SerialName("views_count")
+    val viewCount: Int? = null,
+    @SerialName("is_active")
+    val isActive: Boolean? = null,
+    @SerialName("thumbnail_url")
+    val thumbnailUrl: String? = null,
+    @SerialName("media_width")
+    val mediaWidth: Int? = null,
+    @SerialName("media_height")
+    val mediaHeight: Int? = null,
+    @SerialName("media_duration_seconds")
+    val mediaDurationSeconds: Int? = null,
+    @SerialName("file_size_bytes")
+    val fileSizeBytes: Long? = null,
+    @SerialName("reactions_count")
+    val reactionsCount: Int? = null,
+    @SerialName("replies_count")
+    val repliesCount: Int? = null,
+    @SerialName("is_reported")
+    val isReported: Boolean? = null,
+    @SerialName("moderation_status")
+    val moderationStatus: String? = null,
+    @SerialName("created_at")
+    val createdAt: String? = null,
+    @SerialName("expires_at")
+    val expiresAt: String? = null
+) {
+    fun getEffectiveMediaUrl(): String? {
+        return mediaUrl
+    }
+
+    fun getDisplayDuration(): Int {
+        return when {
+            mediaType == StoryMediaType.VIDEO && mediaDurationSeconds != null -> mediaDurationSeconds
+            duration != null -> duration
+            else -> 5
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/repository/StoryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/repository/StoryRepository.kt
@@ -1,0 +1,12 @@
+package com.synapse.social.studioasinc.shared.domain.repository
+
+import com.synapse.social.studioasinc.shared.domain.model.Story
+
+interface StoryRepository {
+    suspend fun getStories(): List<Story>
+    suspend fun createStory(
+        mediaUrl: String,
+        mediaType: String,
+        textOverlay: String?
+    )
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/story/CreateStoryUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/story/CreateStoryUseCase.kt
@@ -1,0 +1,18 @@
+package com.synapse.social.studioasinc.shared.domain.usecase.story
+
+import com.synapse.social.studioasinc.shared.domain.repository.StoryRepository
+
+class CreateStoryUseCase(private val repository: StoryRepository) {
+    @Throws(Exception::class)
+    suspend operator fun invoke(
+        mediaUrl: String,
+        mediaType: String,
+        textOverlay: String?
+    ) {
+        repository.createStory(
+            mediaUrl = mediaUrl,
+            mediaType = mediaType,
+            textOverlay = textOverlay
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/story/GetStoriesUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/story/GetStoriesUseCase.kt
@@ -1,0 +1,11 @@
+package com.synapse.social.studioasinc.shared.domain.usecase.story
+
+import com.synapse.social.studioasinc.shared.domain.model.Story
+import com.synapse.social.studioasinc.shared.domain.repository.StoryRepository
+
+class GetStoriesUseCase(private val repository: StoryRepository) {
+    @Throws(Exception::class)
+    suspend operator fun invoke(): List<Story> {
+        return repository.getStories()
+    }
+}


### PR DESCRIPTION
This PR replaces the mock Story submission and fetching logic in the iOS application with real KMP UseCase integrations.

**Changes included:**
- Created `Story` domain model, `StoryDto`, `StoryRepository`, and `SupabaseStoryRepository` inside the `shared` KMP module.
- Created `CreateStoryUseCase` and `GetStoriesUseCase` to handle the business logic of creating and retrieving stories, respectively.
- Registered the new UseCases and Repository in `KMPHelper.swift` so they are accessible to iOS logic.
- Updated `StoryCreatorViewModel.swift` to upload the media using `UploadMediaUseCase` and then save the resulting URL using `CreateStoryUseCase`.
- Updated `StoryViewerViewModel.swift` to fetch live story data using `GetStoriesUseCase` instead of emitting dummy data on an artificial delay. 

All KMP dependencies follow standard `Result` propagation by throwing errors that Swift can `try await` upon.

---
*PR created automatically by Jules for task [11443366267031507137](https://jules.google.com/task/11443366267031507137) started by @TheRealAshik*