### PR TITLE
feat: Implement Web auth and feed screens

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
             dependencies {
                 implementation(project(":shared"))
                 implementation("io.insert-koin:koin-core:4.1.1")
+                implementation("io.insert-koin:koin-compose:4.1.1")
                 implementation(compose.runtime)
                 implementation(compose.foundation)
                 implementation(compose.material3)

--- a/web/src/wasmJsMain/kotlin/Main.kt
+++ b/web/src/wasmJsMain/kotlin/Main.kt
@@ -7,25 +7,38 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.CanvasBasedWindow
 import com.synapse.social.studioasinc.shared.di.storageModule
+import com.synapse.social.studioasinc.web.di.webModule
+import com.synapse.social.studioasinc.web.ui.WebAuthScreen
+import com.synapse.social.studioasinc.web.ui.WebFeedScreen
 import org.koin.core.context.startKoin
+
+enum class WebScreen {
+    Landing, Login, Feed
+}
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     startKoin {
-        modules(storageModule)
+        modules(storageModule, webModule)
     }
 
     CanvasBasedWindow(canvasElementId = "ComposeTarget") {
         MaterialTheme {
             Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                WebPremiumLandingPage()
+                var currentScreen by remember { mutableStateOf(WebScreen.Landing) }
+
+                when (currentScreen) {
+                    WebScreen.Landing -> WebPremiumLandingPage(onGetStarted = { currentScreen = WebScreen.Login })
+                    WebScreen.Login -> WebAuthScreen(onLoginSuccess = { currentScreen = WebScreen.Feed })
+                    WebScreen.Feed -> WebFeedScreen()
+                }
             }
         }
     }
 }
 
 @Composable
-fun WebPremiumLandingPage() {
+fun WebPremiumLandingPage(onGetStarted: () -> Unit) {
     Column(
         modifier = Modifier.fillMaxSize().padding(32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -50,7 +63,7 @@ fun WebPremiumLandingPage() {
             Column(modifier = Modifier.padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(text = "Status: Online", style = MaterialTheme.typography.bodyLarge)
                 Spacer(modifier = Modifier.height(16.dp))
-                Button(onClick = { /* Navigate to Login */ }) {
+                Button(onClick = onGetStarted) {
                     Text("Get Started")
                 }
             }

--- a/web/src/wasmJsMain/kotlin/com/synapse/social/studioasinc/web/di/WebModule.kt
+++ b/web/src/wasmJsMain/kotlin/com/synapse/social/studioasinc/web/di/WebModule.kt
@@ -1,0 +1,17 @@
+package com.synapse.social.studioasinc.web.di
+
+import com.synapse.social.studioasinc.shared.data.repository.SupabaseAuthRepository
+import com.synapse.social.studioasinc.shared.data.repository.SearchRepositoryImpl
+import com.synapse.social.studioasinc.shared.domain.repository.AuthRepository
+import com.synapse.social.studioasinc.shared.domain.repository.ISearchRepository
+import com.synapse.social.studioasinc.shared.domain.usecase.auth.SignInUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.search.SearchPostsUseCase
+import org.koin.dsl.module
+
+val webModule = module {
+    single<AuthRepository> { SupabaseAuthRepository() }
+    single { SignInUseCase(get()) }
+
+    single<ISearchRepository> { SearchRepositoryImpl() }
+    single { SearchPostsUseCase(get()) }
+}

--- a/web/src/wasmJsMain/kotlin/com/synapse/social/studioasinc/web/ui/WebAuthScreen.kt
+++ b/web/src/wasmJsMain/kotlin/com/synapse/social/studioasinc/web/ui/WebAuthScreen.kt
@@ -1,0 +1,84 @@
+package com.synapse.social.studioasinc.web.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.synapse.social.studioasinc.shared.domain.usecase.auth.SignInUseCase
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+
+@Composable
+fun WebAuthScreen(onLoginSuccess: () -> Unit) {
+    val signInUseCase: SignInUseCase = koinInject()
+    val scope = rememberCoroutineScope()
+
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var isLoading by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text("Sign In", style = MaterialTheme.typography.headlineMedium)
+        Spacer(modifier = Modifier.height(32.dp))
+
+        OutlinedTextField(
+            value = email,
+            onValueChange = { email = it },
+            label = { Text("Email") },
+            modifier = Modifier.fillMaxWidth(0.5f),
+            singleLine = true
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Password") },
+            modifier = Modifier.fillMaxWidth(0.5f),
+            visualTransformation = PasswordVisualTransformation(),
+            singleLine = true
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+
+        if (errorMessage != null) {
+            Text(errorMessage!!, color = MaterialTheme.colorScheme.error)
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        Button(
+            onClick = {
+                if (email.isBlank() || password.isBlank()) {
+                    errorMessage = "Please enter email and password"
+                    return@Button
+                }
+                isLoading = true
+                errorMessage = null
+                scope.launch {
+                    val result = signInUseCase(email, password)
+                    isLoading = false
+                    if (result.isSuccess) {
+                        onLoginSuccess()
+                    } else {
+                        errorMessage = result.exceptionOrNull()?.message ?: "Login failed"
+                    }
+                }
+            },
+            enabled = !isLoading,
+            modifier = Modifier.fillMaxWidth(0.5f)
+        ) {
+            if (isLoading) {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp), color = MaterialTheme.colorScheme.onPrimary)
+            } else {
+                Text("Login")
+            }
+        }
+    }
+}

--- a/web/src/wasmJsMain/kotlin/com/synapse/social/studioasinc/web/ui/WebFeedScreen.kt
+++ b/web/src/wasmJsMain/kotlin/com/synapse/social/studioasinc/web/ui/WebFeedScreen.kt
@@ -1,0 +1,103 @@
+package com.synapse.social.studioasinc.web.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.synapse.social.studioasinc.shared.domain.model.SearchPost
+import com.synapse.social.studioasinc.shared.domain.usecase.search.SearchPostsUseCase
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+
+@Composable
+fun WebFeedScreen() {
+    val searchPostsUseCase: SearchPostsUseCase = koinInject()
+    val scope = rememberCoroutineScope()
+
+    var posts by remember { mutableStateOf<List<SearchPost>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        isLoading = true
+        val result = searchPostsUseCase("") // Empty query to get recent posts
+        isLoading = false
+        if (result.isSuccess) {
+            posts = result.getOrNull() ?: emptyList()
+        } else {
+            errorMessage = result.exceptionOrNull()?.message ?: "Failed to load posts"
+        }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp)
+    ) {
+        Text("Feed", style = MaterialTheme.typography.headlineMedium)
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (isLoading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else if (errorMessage != null) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(errorMessage!!, color = MaterialTheme.colorScheme.error)
+            }
+        } else if (posts.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("No posts available")
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                items(posts) { post ->
+                    PostCard(post)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PostCard(post: SearchPost) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = post.authorName ?: post.authorHandle ?: "Unknown User",
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            if (!post.content.isNullOrBlank()) {
+                Text(
+                    text = post.content!!,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            } else {
+                Text(
+                    text = "Media post",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text("${post.likesCount} Likes", style = MaterialTheme.typography.bodySmall)
+                Text("${post.commentsCount} Comments", style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the missing auth and feed screens for the Web target, transitioning it from a static placeholder to a functional app. It defines a Koin module for Web dependencies, creates `WebAuthScreen` for login (using `SignInUseCase`), creates `WebFeedScreen` for displaying the latest posts (using `SearchPostsUseCase`), and adds state-based navigation logic to `Main.kt`. The `koin-compose` dependency was also added to allow dependency injection within Compose for Web.

---
*PR created automatically by Jules for task [15286291634589290979](https://jules.google.com/task/15286291634589290979) started by @TheRealAshik*