### PR TITLE
🧪 [testing improvement] Add tests for SupabaseClient.constructStorageUrl

### DIFF
--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/core/network/SupabaseClient.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/core/network/SupabaseClient.kt
@@ -90,6 +90,10 @@ object SupabaseClient {
     }
 
     fun constructStorageUrl(bucket: String, path: String): String {
+        return constructStorageUrlInternal(validatedSupabaseUrl, bucket, path)
+    }
+
+    internal fun constructStorageUrlInternal(baseUrl: String, bucket: String, path: String): String {
         if (path.startsWith("http://") || path.startsWith("https://")) {
             return path
         }
@@ -97,7 +101,7 @@ object SupabaseClient {
         // Remove leading slash if present to avoid double slashes
         val cleanPath = if (path.startsWith("/")) path.substring(1) else path
 
-        return "$validatedSupabaseUrl/storage/v1/object/public/$bucket/$cleanPath"
+        return "$baseUrl/storage/v1/object/public/$bucket/$cleanPath"
     }
 
     fun constructMediaUrl(storagePath: String): String {

--- a/shared/src/commonTest/kotlin/com/synapse/social/studioasinc/shared/core/network/SupabaseClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/synapse/social/studioasinc/shared/core/network/SupabaseClientTest.kt
@@ -1,0 +1,62 @@
+package com.synapse.social.studioasinc.shared.core.network
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SupabaseClientTest {
+
+    private val baseUrl = "https://example.supabase.co"
+
+    @Test
+    fun testConstructStorageUrl_HappyPath() {
+        val bucket = "avatars"
+        val path = "user123.png"
+        val expected = "$baseUrl/storage/v1/object/public/$bucket/$path"
+
+        val actual = SupabaseClient.constructStorageUrlInternal(baseUrl, bucket, path)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testConstructStorageUrl_WithLeadingSlash() {
+        val bucket = "posts"
+        val path = "/images/post1.jpg"
+        val expected = "$baseUrl/storage/v1/object/public/$bucket/images/post1.jpg"
+
+        val actual = SupabaseClient.constructStorageUrlInternal(baseUrl, bucket, path)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testConstructStorageUrl_AlreadyFullHttpUrl() {
+        val bucket = "any"
+        val path = "http://external.com/image.png"
+
+        val actual = SupabaseClient.constructStorageUrlInternal(baseUrl, bucket, path)
+
+        assertEquals(path, actual)
+    }
+
+    @Test
+    fun testConstructStorageUrl_AlreadyFullHttpsUrl() {
+        val bucket = "any"
+        val path = "https://external.com/image.png"
+
+        val actual = SupabaseClient.constructStorageUrlInternal(baseUrl, bucket, path)
+
+        assertEquals(path, actual)
+    }
+
+    @Test
+    fun testConstructStorageUrl_NestedPath() {
+        val bucket = "docs"
+        val path = "folder/subfolder/file.pdf"
+        val expected = "$baseUrl/storage/v1/object/public/$bucket/$path"
+
+        val actual = SupabaseClient.constructStorageUrlInternal(baseUrl, bucket, path)
+
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
🎯 **What:** This change addresses the testing gap for `SupabaseClient.constructStorageUrl`.
📊 **Coverage:** 
- Happy path for storage URL construction.
- Proper handling of paths with leading slashes (prevention of double slashes).
- Handling of paths that are already full URLs (HTTP and HTTPS).
- Verification of nested path construction.
✨ **Result:** Improved reliability of storage URL generation across the shared module. logic was refactored to be pure and testable without relying on global state.

---
*PR created automatically by Jules for task [10268224270318273060](https://jules.google.com/task/10268224270318273060) started by @TheRealAshik*