### PR TITLE
🐛 fix: Inbox swipe action width matches card bounds

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatsTabScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatsTabScreen.kt
@@ -159,6 +159,7 @@ fun ChatsTabScreen(
                     }
 
                     SwipeToDismissBox(
+                        modifier = Modifier.padding(horizontal = Spacing.Medium),
                         state = dismissState,
                         backgroundContent = {
                             val isStartToEnd = dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd
@@ -260,7 +261,6 @@ private fun ConversationItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = Spacing.Medium)
             .clip(shape)
             .background(MaterialTheme.colorScheme.surfaceContainer, shape)
             .combinedClickable(


### PR DESCRIPTION
Fixes an issue where the swipe-to-dismiss background in the inbox expands wider than the conversation item when the user swipes. 

Root Cause:
In `ChatsTabScreen.kt`, the `ConversationItem` composable's root `Row` had `padding(horizontal = Spacing.Medium)` applied before the background/clip modifiers, making the visible card narrower than the `SwipeToDismissBox`.

Fix:
- Removed `.padding(horizontal = Spacing.Medium)` from the `Row` modifier in `ConversationItem`.
- Wrapped `SwipeToDismissBox` in `ChatsTabScreen` with the horizontal padding instead.

---
*PR created automatically by Jules for task [4556708983425934209](https://jules.google.com/task/4556708983425934209) started by @TheRealAshik*