### PR TITLE
🐛 fix: prevent duplicate notifications during chat media upload

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/core/util/UploadProgressManager.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/core/util/UploadProgressManager.kt
@@ -19,10 +19,6 @@ class UploadProgressManager @Inject constructor(
 
         val title = "Uploading $fileName"
         NotificationHelper.showProgressNotification(context, notificationId, progress, title)
-
-        if (progress >= 100) {
-            uploadIds.remove(key)
-        }
     }
 
     fun showProgress(id: Int, percentage: Int, title: String) {
@@ -45,7 +41,7 @@ class UploadProgressManager @Inject constructor(
         val id = uploadIds.getOrPut(key) { notificationIdGenerator.incrementAndGet() }
         val progress = if (success) 100 else 0
         NotificationHelper.showProgressNotification(context, id, progress, title)
-        if (!success) uploadIds.remove(key)
+        uploadIds.remove(key)
     }
 
     fun dismissProgress(id: Int) {


### PR DESCRIPTION
Fixed premature key removal in UploadProgressManager.updateProgress() that caused a new notification ID to be generated on subsequent lifecycle calls.
Each upload was spawning 2+ system notifications — one from the progress updates and another from the dismiss/finish call.

---
*PR created automatically by Jules for task [14857716816316280259](https://jules.google.com/task/14857716816316280259) started by @TheRealAshik*