### PR TITLE
✨ feat: Add editable content scale for story photos

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/creator/StoryCreatorViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/creator/StoryCreatorViewModel.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
+import androidx.compose.ui.layout.ContentScale
 import androidx.lifecycle.viewModelScope
 import com.synapse.social.studioasinc.core.auth.AuthHelper
 import com.synapse.social.studioasinc.data.repository.StoryRepository
@@ -57,7 +58,8 @@ data class StoryCreatorState(
     val isPosting: Boolean = false,
     val isPosted: Boolean = false,
     val error: String? = null,
-    val sharedPost: Post? = null
+    val sharedPost: Post? = null,
+    val contentScale: ContentScale = ContentScale.Crop
 )
 
 @HiltViewModel
@@ -320,6 +322,18 @@ class StoryCreatorViewModel @Inject constructor(
 
     fun clearError() {
         _state.update { it.copy(error = null) }
+    }
+
+    fun cycleContentScale() {
+        _state.update { state ->
+            val nextScale = when (state.contentScale) {
+                ContentScale.Crop -> ContentScale.Fit
+                ContentScale.Fit -> ContentScale.FillBounds
+                ContentScale.FillBounds -> ContentScale.Inside
+                else -> ContentScale.Crop
+            }
+            state.copy(contentScale = nextScale)
+        }
     }
 
     override fun onCleared() {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/creator/StoryEditor.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/creator/StoryEditor.kt
@@ -130,6 +130,7 @@ internal fun StoryEditor(
             onToggleDrawingMode = { isDrawingMode = !isDrawingMode },
             onAddText = { viewModel.addTextOverlay() },
             onAddSticker = { showStickerPicker = true },
+            onCycleScaleMode = { viewModel.cycleContentScale() },
             modifier = Modifier.align(Alignment.TopCenter)
         )
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/creator/StoryEditorComponents.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/creator/StoryEditorComponents.kt
@@ -56,6 +56,7 @@ import androidx.media3.ui.PlayerView
 import coil.compose.AsyncImage
 import com.synapse.social.studioasinc.R
 import com.synapse.social.studioasinc.domain.model.StoryMediaType
+import androidx.compose.material.icons.filled.Crop
 import com.synapse.social.studioasinc.feature.shared.theme.Sizes
 import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 import kotlin.math.roundToInt
@@ -214,6 +215,7 @@ internal fun StoryTopControls(
     onToggleDrawingMode: () -> Unit,
     onAddText: () -> Unit,
     onAddSticker: () -> Unit,
+    onCycleScaleMode: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -228,6 +230,9 @@ internal fun StoryTopControls(
         }
 
         Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onCycleScaleMode) {
+                Icon(Icons.Default.Crop, contentDescription = stringResource(R.string.story_cycle_scale), tint = MaterialTheme.colorScheme.onPrimary)
+            }
             IconButton(onClick = onAddText) {
                 Text(
                     stringResource(R.string.story_text_button_label),
@@ -325,7 +330,7 @@ internal fun StoryBackground(state: StoryCreatorState) {
                 model = mediaUri,
                 contentDescription = null,
                 modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
+                contentScale = state.contentScale
             )
         }
     } else if (state.sharedPost != null) {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/viewer/StoryViewerScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/viewer/StoryViewerScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Crop
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -97,9 +98,22 @@ fun StoryViewerScreen(
                 StoryMediaContent(
                     story = currentStory,
                     isPaused = uiState.isPaused,
+                    contentScale = uiState.contentScale,
                     onVideoReady = { duration -> viewModel.onVideoReady(duration) }
                 )
 
+                IconButton(
+                    onClick = { viewModel.cycleContentScale() },
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(Spacing.Medium)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Crop,
+                        contentDescription = stringResource(R.string.story_cycle_scale),
+                        tint = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
 
                 Column(
                     modifier = Modifier
@@ -132,6 +146,7 @@ fun StoryViewerScreen(
 fun StoryMediaContent(
     story: Story,
     isPaused: Boolean,
+    contentScale: ContentScale,
     onVideoReady: (Long) -> Unit
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
@@ -146,7 +161,7 @@ fun StoryMediaContent(
                 model = story.mediaUrl,
                 contentDescription = null,
                 modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
+                contentScale = contentScale
             )
         }
     }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/viewer/StoryViewerViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/viewer/StoryViewerViewModel.kt
@@ -6,6 +6,7 @@ import com.synapse.social.studioasinc.shared.domain.repository.AuthRepository
 import com.synapse.social.studioasinc.data.repository.StoryRepository
 import com.synapse.social.studioasinc.data.repository.UserRepositoryImpl
 import com.synapse.social.studioasinc.domain.model.Story
+import androidx.compose.ui.layout.ContentScale
 import com.synapse.social.studioasinc.domain.model.StoryMediaType
 import com.synapse.social.studioasinc.domain.model.User
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -26,7 +27,8 @@ data class StoryViewerState(
     val currentStoryIndex: Int = 0,
     val progress: Float = 0f,
     val isPaused: Boolean = false,
-    val isFinished: Boolean = false
+    val isFinished: Boolean = false,
+    val contentScale: ContentScale = ContentScale.Crop
 )
 
 @HiltViewModel
@@ -210,6 +212,18 @@ class StoryViewerViewModel @Inject constructor(
 
 
         startProgress(durationOverride = durationMs)
+    }
+
+    fun cycleContentScale() {
+        _uiState.update { state ->
+            val nextScale = when (state.contentScale) {
+                ContentScale.Crop -> ContentScale.Fit
+                ContentScale.Fit -> ContentScale.FillBounds
+                ContentScale.FillBounds -> ContentScale.Inside
+                else -> ContentScale.Crop
+            }
+            state.copy(contentScale = nextScale)
+        }
     }
 
     private fun markAsSeen(storyId: String?) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1430,6 +1430,7 @@ Please explain the following message from %3$s in detail, considering the contex
     <string name="privacy_post_visibility_desc">Your post will appear in Feed, on your profile and in search results.</string>
     <string name="add_content">Add content</string>
     <string name="cd_attached_media">Attached media</string>
+    <string name="story_cycle_scale">Change scale</string>
 
     <string name="complete_profile_title_dialog">Complete Your Profile</string>
     <string name="complete_profile_body">Add a profile picture, bio, and more to personalize your account and connect with others.</string>


### PR DESCRIPTION
Added user-selectable ContentScale (Crop/Fit/FillBounds/Inside) for story media in both creator and viewer. Users can now control how their photos fit the screen instead of being locked to center crop.

---
*PR created automatically by Jules for task [5114711879116292767](https://jules.google.com/task/5114711879116292767) started by @TheRealAshik*