### PR TITLE
✨ feat: Unify avatar fallback to first-name initial across entire app

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/CreateGroupScreen.kt
@@ -152,13 +152,10 @@ private fun UserSelectionItem(
             .padding(Spacing.Medium),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        AsyncImage(
-            model = user.avatar ?: "",
-            contentDescription = null,
-            modifier = Modifier
-                .size(Sizes.IconMassive)
-                .clip(CircleShape),
-            contentScale = ContentScale.Crop
+        com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
+            avatarUrl = user.avatar,
+            displayName = user.displayName ?: user.username,
+            size = Sizes.IconMassive
         )
         Spacer(modifier = Modifier.width(Spacing.Medium))
         Text(
@@ -187,13 +184,10 @@ private fun SelectedUserItem(
         modifier = Modifier.width(Sizes.AvatarLarge)
     ) {
         Box {
-            AsyncImage(
-                model = user.avatar ?: "",
-                contentDescription = null,
-                modifier = Modifier
-                    .size(Sizes.AvatarDefault)
-                    .clip(CircleShape),
-                contentScale = ContentScale.Crop
+            com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
+                avatarUrl = user.avatar,
+                displayName = user.displayName ?: user.username,
+                size = Sizes.AvatarDefault
             )
             Surface(
                 shape = CircleShape,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatIntroHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatIntroHeader.kt
@@ -32,20 +32,19 @@ fun ChatIntroHeader(
             .padding(vertical = Spacing.ExtraLarge, horizontal = Spacing.Medium),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        AsyncImage(
-            model = avatarUrl,
-            contentDescription = stringResource(id = R.string.cd_profile_picture),
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .size(96.dp)
-                .clip(RoundedCornerShape(20.dp))
+        val rawName = participantProfile?.displayName ?: participantProfile?.name
+            ?: participantProfile?.username?.replace("_", " ")?.split(" ")?.joinToString(" ") { it.replaceFirstChar { c -> c.uppercase() } }
+            ?: initialParticipantName ?: ""
+
+        com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
+            avatarUrl = avatarUrl,
+            displayName = rawName,
+            size = 96.dp,
+            shape = RoundedCornerShape(20.dp)
         )
 
         Spacer(modifier = Modifier.height(Spacing.Medium))
 
-        val rawName = participantProfile?.displayName ?: participantProfile?.name
-            ?: participantProfile?.username?.replace("_", " ")?.split(" ")?.joinToString(" ") { it.replaceFirstChar { c -> c.uppercase() } }
-            ?: initialParticipantName ?: ""
         Text(
             text = rawName,
             style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/InboxTopAppBar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/InboxTopAppBar.kt
@@ -56,29 +56,12 @@ fun InboxLargeTopAppBar(
         },
         actions = {
 
-             Box(
-                 modifier = Modifier
-                     .size(Sizes.IconMassive)
-                     .clip(CircleShape)
-                     .background(MaterialTheme.colorScheme.primary)
-                     .clickable(onClick = onProfileClick),
-                 contentAlignment = Alignment.Center
-             ) {
-                 if (avatarUrl != null) {
-                     AsyncImage(
-                         model = avatarUrl,
-                         contentDescription = "Profile",
-                         modifier = Modifier.fillMaxSize(),
-                         contentScale = ContentScale.Crop
-                     )
-                 } else {
-                     Text(
-                         text = stringResource(R.string.default_avatar_letter),
-                         style = MaterialTheme.typography.titleMedium,
-                         color = MaterialTheme.colorScheme.onPrimary
-                     )
-                 }
-             }
+             com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
+                 avatarUrl = avatarUrl,
+                 displayName = title,
+                 size = Sizes.IconMassive,
+                 modifier = Modifier.clickable(onClick = onProfileClick)
+             )
 
              Spacer(modifier = Modifier.width(Spacing.Medium))
         },

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
@@ -640,17 +640,11 @@ fun MessageBubble(
 
         if (isFromMe && (position == GroupPosition.LAST || position == GroupPosition.SINGLE)
             && message.deliveryStatus == DeliveryStatus.READ) {
-            AsyncImage(
-                model = senderAvatarUrl,
-                contentDescription = stringResource(R.string.chat_cd_reader_avatar),
-                contentScale = ContentScale.Crop,
-                placeholder = rememberVectorPainter(Icons.Filled.Person),
-                error = rememberVectorPainter(Icons.Filled.Person),
-                modifier = Modifier
-                    .padding(top = Spacing.Tiny)
-                    .size(Sizes.AvatarTiny)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant)
+            com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
+                avatarUrl = senderAvatarUrl,
+                displayName = null,
+                size = Sizes.AvatarTiny,
+                modifier = Modifier.padding(top = Spacing.Tiny)
             )
         }
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatsTabScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatsTabScreen.kt
@@ -272,14 +272,11 @@ private fun ConversationItem(
     ) {
         // Avatar with online indicator
         Box {
-            AsyncImage(
-                model = conversation.participantAvatar,
-                contentDescription = null,
+            com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
+                avatarUrl = conversation.participantAvatar,
+                displayName = conversation.participantName,
+                size = InboxTheme.dimens.AvatarSize,
                 modifier = Modifier
-                    .size(InboxTheme.dimens.AvatarSize)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant, CircleShape),
-                contentScale = ContentScale.Crop
             )
             if (conversation.isOnline) {
                 Box(

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/components/CoverPhoto.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/components/CoverPhoto.kt
@@ -254,30 +254,15 @@ fun ProfileImageWithRing(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(if (hasStory) ringWidth + ringPadding else Spacing.ExtraSmall)
-                .clip(shape)
+                .clip(shape),
+            contentAlignment = Alignment.Center
         ) {
-            if (avatar != null) {
-                AsyncImage(
-                    model = avatar,
-                    contentDescription = stringResource(R.string.author_avatar),
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
-                )
-            } else {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surfaceVariant),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Person,
-                        contentDescription = null,
-                        modifier = Modifier.size(size * 0.5f),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
+            com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
+                avatarUrl = avatar,
+                displayName = null,
+                size = size,
+                modifier = Modifier.fillMaxSize()
+            )
         }
 
         if (status == UserStatus.ONLINE) {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/search/search/components/AccountCard.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/search/search/components/AccountCard.kt
@@ -58,19 +58,10 @@ fun AccountCard(
             .padding(horizontal = Spacing.Medium, vertical = Spacing.SmallMedium),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(account.avatarUrl)
-                .crossfade(true)
-                .build(),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            placeholder = rememberVectorPainter(Icons.Filled.Person),
-            error = rememberVectorPainter(Icons.Filled.Person),
-            modifier = Modifier
-                .size(Sizes.IconGiant)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceVariant)
+        com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
+            avatarUrl = account.avatarUrl,
+            displayName = account.displayName ?: account.handle,
+            size = Sizes.IconGiant
         )
 
         Spacer(modifier = Modifier.width(Spacing.Medium))

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/Avatar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/Avatar.kt
@@ -1,19 +1,20 @@
 package com.synapse.social.studioasinc.ui.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import com.synapse.social.studioasinc.R
 
 @Composable
 fun CircularAvatar(
@@ -21,6 +22,7 @@ fun CircularAvatar(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     size: Dp = 48.dp,
+    displayName: String? = null,
     onClick: (() -> Unit)? = null
 ) {
     val imageModifier = modifier
@@ -28,21 +30,24 @@ fun CircularAvatar(
         .clip(CircleShape)
         .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
 
-    if (imageUrl != null) {
+    if (!imageUrl.isNullOrBlank()) {
         AsyncImage(
             model = imageUrl,
             contentDescription = contentDescription,
             modifier = imageModifier,
-            contentScale = ContentScale.Crop,
-            placeholder = rememberVectorPainter(Icons.Filled.Person),
-            error = rememberVectorPainter(Icons.Filled.Person)
-        )
-    } else {
-        androidx.compose.foundation.Image(
-            painter = rememberVectorPainter(Icons.Filled.Person),
-            contentDescription = contentDescription,
-            modifier = imageModifier,
             contentScale = ContentScale.Crop
         )
+    } else {
+        Box(
+            modifier = imageModifier
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = displayName?.firstOrNull { it.isLetterOrDigit() }?.uppercaseChar()?.toString() ?: displayName?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/UserAvatar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/UserAvatar.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import coil.compose.AsyncImage
@@ -18,18 +19,20 @@ import coil.compose.AsyncImage
 fun UserAvatar(
     avatarUrl: String?,
     size: Dp,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    displayName: String? = null,
+    shape: Shape = CircleShape
 ) {
     if (avatarUrl.isNullOrBlank()) {
         Box(
             modifier = modifier
                 .size(size)
-                .clip(CircleShape)
+                .clip(shape)
                 .background(MaterialTheme.colorScheme.primaryContainer),
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = "?",
+                text = displayName?.firstOrNull { it.isLetterOrDigit() }?.uppercaseChar()?.toString() ?: displayName?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onPrimaryContainer
             )
@@ -40,7 +43,7 @@ fun UserAvatar(
             contentDescription = "User avatar",
             modifier = modifier
                 .size(size)
-                .clip(CircleShape),
+                .clip(shape),
             contentScale = ContentScale.Crop
         )
     }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/SettingsProfileComponents.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/SettingsProfileComponents.kt
@@ -52,36 +52,12 @@ fun ProfileHeaderCard(
             Box(
                 modifier = Modifier.size(SettingsSpacing.avatarSize)
             ) {
-                if (avatarUrl != null && avatarUrl.isNotBlank()) {
-                    AsyncImage(
-                        model = ImageLoader.buildImageRequest(LocalContext.current, avatarUrl),
-                        contentDescription = "$profileAvatarDescription, $displayName",
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .clip(CircleShape),
-                        contentScale = ContentScale.Crop
-                    )
-                } else {
-
-                    Surface(
-                        modifier = Modifier.fillMaxSize(),
-                        shape = CircleShape,
-                        color = MaterialTheme.colorScheme.primaryContainer
-                    ) {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Person,
-                                contentDescription = "$profileAvatarDescription, $displayName",
-                                modifier = Modifier.size(Sizes.IconHuge),
-                                tint = MaterialTheme.colorScheme.onPrimaryContainer
-                            )
-                        }
-                    }
-                }
-
+                com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
+                    avatarUrl = avatarUrl,
+                    displayName = displayName,
+                    size = SettingsSpacing.avatarSize,
+                    modifier = Modifier.fillMaxSize()
+                )
 
                 Surface(
                     modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
Single fallback pattern — first letter of display name in `primaryContainer` circle — replacing `"?"`, `Person` icon, and gray `surfaceVariant` backgrounds. Updates UserAvatar and CircularAvatar, and migrates all raw AsyncImage usages for avatars to use the new standardized components.

---
*PR created automatically by Jules for task [6952957864913974027](https://jules.google.com/task/6952957864913974027) started by @TheRealAshik*