### PR TITLE
🐛 fix: Repair chat message pagination

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
@@ -339,10 +339,12 @@ class ChatViewModel @Inject constructor(
     fun loadMoreMessages() {
         val chatId = currentChatId ?: return
         if (_isLoadingMore.value || !_hasMoreMessages.value) return
-        val oldest = messagingDelegate.messages.value.firstOrNull()?.createdAt ?: return
+        val oldestMessage = messagingDelegate.messages.value.firstOrNull() ?: return
+        val oldest = oldestMessage.createdAt
+        val oldestId = oldestMessage.id
         _isLoadingMore.value = true
         viewModelScope.launch {
-            getMessagesUseCase(chatId, before = oldest).onSuccess { older ->
+            getMessagesUseCase(chatId, before = oldest, beforeId = oldestId).onSuccess { older ->
                 if (older.isEmpty()) {
                     _hasMoreMessages.value = false
                 } else {
@@ -537,6 +539,7 @@ class ChatViewModel @Inject constructor(
         subscriptionDelegate.cleanup()
         inputDelegate.cleanup()
         messagingDelegate.pendingTempIds.value = emptySet()
+        _hasMoreMessages.value = true
     }
 
     override fun onCleared() {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatMessageList.kt
@@ -64,8 +64,8 @@ internal fun ChatMessageList(
             val info = listState.layoutInfo
             val total = info.totalItemsCount
             if (total < 5) return@derivedStateOf false
-            val lastVisible = info.visibleItemsInfo.lastOrNull()?.index ?: 0
-            lastVisible >= total - 3
+            val highestVisibleIndex = info.visibleItemsInfo.maxOfOrNull { it.index } ?: 0
+            highestVisibleIndex >= total - 3
         }
     }
     LaunchedEffect(shouldLoadMore.value) {

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/ChatMessageDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/ChatMessageDataSource.kt
@@ -22,22 +22,26 @@ internal class ChatMessageDataSource(private val client: SupabaseClientLib) {
 
     private fun getCurrentUserId(): String? = client.auth.currentUserOrNull()?.id
 
-    suspend fun getMessages(chatId: String, limit: Int = 50, before: String? = null): List<MessageDto> =
+    suspend fun getMessages(chatId: String, limit: Int = 50, before: String? = null, beforeId: String? = null): List<MessageDto> =
         withContext(AppDispatchers.IO) {
             try {
                 client.postgrest.from("messages").select {
                     filter {
                         eq("chat_id", chatId)
                         eq("is_deleted", false)
-                    or {
-                        filter("expires_at", FilterOperator.IS, "null")
-                        gt("expires_at", kotlinx.datetime.Clock.System.now().toString())
+                        or {
+                            filter("expires_at", FilterOperator.IS, "null")
+                            gt("expires_at", kotlinx.datetime.Clock.System.now().toString())
+                        }
+                        if (before != null && beforeId != null) {
+                            lte("created_at", before)
+                            neq("id", beforeId)
+                        } else if (before != null) {
+                            lt("created_at", before)
+                        }
                     }
-                    if (before != null) {
-                        lt("created_at", before)
-                    }
-                }
                     order("created_at", Order.DESCENDING)
+                    order("id", Order.DESCENDING)
                     limit(limit.toLong())
                 }.decodeList<MessageDto>().reversed()
             } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/SupabaseChatDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/SupabaseChatDataSource.kt
@@ -30,8 +30,8 @@ class SupabaseChatDataSource(private val client: SupabaseClientLib = SupabaseCli
     suspend fun getUnreadCount(chatId: String, lastReadAt: String?): Int =
         conversations.getUnreadCount(chatId, lastReadAt)
 
-    suspend fun getMessages(chatId: String, limit: Int = 50, before: String? = null): List<MessageDto> =
-        messages.getMessages(chatId, limit, before)
+    suspend fun getMessages(chatId: String, limit: Int = 50, before: String? = null, beforeId: String? = null): List<MessageDto> =
+        messages.getMessages(chatId, limit, before, beforeId)
 
     suspend fun sendMessage(
         chatId: String, 

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseChatRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseChatRepository.kt
@@ -131,14 +131,14 @@ class SupabaseChatRepository(
         }
     }
 
-    override suspend fun getMessages(chatId: String, limit: Int, before: String?): Result<List<Message>> = try {
+    override suspend fun getMessages(chatId: String, limit: Int, before: String?, beforeId: String?): Result<List<Message>> = try {
         val currentUserId = getCurrentUserId() ?: throw Exception("Not logged in")
         
         val cached = if (before == null) cachedMessageDao?.getMessages(chatId, limit) ?: emptyList() else emptyList()
         if (before == null && cached.isNotEmpty()) {
             externalScope.launch {
                 try {
-                    val fresh = dataSource.getMessages(chatId, limit, null)
+                    val fresh = dataSource.getMessages(chatId, limit, null, null)
                     val decrypted = fresh.map { with(encryptionHelper) { it.decryptIfNecessary(currentUserId).toDomain() } }
                     val latestCached = cachedMessageDao?.getMessages(chatId, limit * 2) ?: emptyList()
                     val mergedMessages = decrypted.map { freshMsg ->
@@ -157,7 +157,7 @@ class SupabaseChatRepository(
             }
             Result.success(cached)
         } else {
-            val messageDtos = dataSource.getMessages(chatId, limit, before)
+            val messageDtos = dataSource.getMessages(chatId, limit, before, beforeId)
             val decrypted = messageDtos.map { with(encryptionHelper) { it.decryptIfNecessary(currentUserId).toDomain() } }
 
             if (before == null) {

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/repository/ChatRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/repository/ChatRepository.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface ChatRepository {
     suspend fun getConversations(): Result<List<Conversation>>
-    suspend fun getMessages(chatId: String, limit: Int = 50, before: String? = null): Result<List<Message>>
+    suspend fun getMessages(chatId: String, limit: Int = 50, before: String? = null, beforeId: String? = null): Result<List<Message>>
     suspend fun getMessageById(messageId: String): Result<Message?>
     suspend fun sendMessage(chatId: String, content: String, mediaUrl: String? = null, messageType: String = "text", expiresAt: String? = null, replyToId: String? = null, senderPlaintext: String? = null): Result<Message>
     suspend fun getOrCreateChat(otherUserId: String): Result<String>

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/chat/GetMessagesUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/chat/GetMessagesUseCase.kt
@@ -6,10 +6,10 @@ import com.synapse.social.studioasinc.shared.domain.repository.ChatRepository
 class GetMessagesUseCase(
     private val repository: ChatRepository
 ) {
-    suspend operator fun invoke(chatId: String, limit: Int = 50, before: String? = null): Result<List<Message>> {
+    suspend operator fun invoke(chatId: String, limit: Int = 50, before: String? = null, beforeId: String? = null): Result<List<Message>> {
         // Decryption is already handled at the repository layer (SupabaseChatRepository.decryptIfNecessary).
         // Do NOT decrypt again here — Signal Protocol's Double Ratchet consumes the key on first use,
         // so a second decryption attempt would fail and leave messages showing "Message is encrypted".
-        return repository.getMessages(chatId, limit, before)
+        return repository.getMessages(chatId, limit, before, beforeId)
     }
 }


### PR DESCRIPTION
Fixes chat message pagination bugs in the Synapse Social app.
- Cursor reliability: Older messages wouldn't load if multiple messages had the exact same `created_at` timestamp. Modified the `getMessages` data source query to use a composite cursor (`before` timestamp + `beforeId`) to break ties and prevent infinite loops.
- Scroll trigger: The `LazyColumn` uses `reverseLayout = true`, so `lastOrNull()` was returning the bottom of the screen instead of the top. Fixed by using `maxOfOrNull { it.index }` to detect when the user is nearing the highest index (oldest messages).
- Chat switching: `_hasMoreMessages` was not resetting when switching chats, preventing pagination in newly opened chats. Added a reset to the `cleanup()` function.

---
*PR created automatically by Jules for task [10208580543548220893](https://jules.google.com/task/10208580543548220893) started by @TheRealAshik*