### PR TITLE
feat(ios): implement complete notifications feature

### DIFF
--- a/iosApp/iosApp/Chat/Models/KMPHelper.swift
+++ b/iosApp/iosApp/Chat/Models/KMPHelper.swift
@@ -27,6 +27,10 @@ class KMPHelper {
 
     let sharedImageLoader: shared.SharedImageLoader
 
+    let getNotificationsUseCase: shared.GetNotificationsUseCase
+    let markNotificationAsReadUseCase: shared.MarkNotificationAsReadUseCase
+    let subscribeToNotificationsUseCase: shared.SubscribeToNotificationsUseCase
+
     init() {
         let fileUploader = shared.FileUploader()
         let imgBBService = shared.ImgBBUploadService(httpClient: shared.SupabaseClient.shared.httpClient)
@@ -74,5 +78,11 @@ class KMPHelper {
         self.getStoriesUseCase = shared.GetStoriesUseCase(repository: storyRepository)
 
         self.sharedImageLoader = shared.SharedImageLoader(httpClient: shared.Ktor_client_coreHttpClient())
+
+        let notificationRepository = shared.SupabaseNotificationRepository(client: shared.SupabaseClient.shared.client)
+
+        self.getNotificationsUseCase = shared.GetNotificationsUseCase(notificationRepository: notificationRepository, authRepository: shared.IOSDependencies.shared.getAuthRepository())
+        self.markNotificationAsReadUseCase = shared.MarkNotificationAsReadUseCase(notificationRepository: notificationRepository, authRepository: shared.IOSDependencies.shared.getAuthRepository())
+        self.subscribeToNotificationsUseCase = shared.SubscribeToNotificationsUseCase(notificationRepository: notificationRepository, authRepository: shared.IOSDependencies.shared.getAuthRepository())
     }
 }

--- a/iosApp/iosApp/Core/DI/DependencyContainer.swift
+++ b/iosApp/iosApp/Core/DI/DependencyContainer.swift
@@ -41,4 +41,8 @@ class DependencyContainer: ObservableObject {
     func makeHomeViewModel() -> HomeViewModel {
         return HomeViewModel(analyticsService: analyticsService)
     }
+
+    func makeNotificationsViewModel() -> NotificationsViewModel {
+        return NotificationsViewModel()
+    }
 }

--- a/iosApp/iosApp/Features/Notifications/NotificationRowView.swift
+++ b/iosApp/iosApp/Features/Notifications/NotificationRowView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+struct NotificationRowView: View {
+    let notification: NotificationItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // Unread indicator dot
+            Circle()
+                .fill(Color.blue)
+                .frame(width: 8, height: 8)
+                .opacity(notification.isRead ? 0 : 1)
+                .padding(.top, 16) // Align with avatar roughly
+
+            // Avatar
+            if let avatarUrlString = notification.actorAvatar, let url = URL(string: avatarUrlString) {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .empty:
+                        Circle()
+                            .fill(Color.gray.opacity(0.3))
+                            .frame(width: 40, height: 40)
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 40, height: 40)
+                            .clipShape(Circle())
+                    case .failure:
+                        fallbackAvatar
+                    @unknown default:
+                        fallbackAvatar
+                    }
+                }
+            } else {
+                fallbackAvatar
+            }
+
+            // Content
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 4) {
+                    Text(notification.actorName)
+                        .font(.subheadline)
+                        .fontWeight(.bold)
+                        .foregroundColor(.primary)
+
+                    Text(notification.message)
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+                }
+                .lineLimit(2)
+
+                HStack(spacing: 6) {
+                    typeIcon
+                        .foregroundColor(.secondary)
+                        .font(.caption)
+
+                    Text(notification.timestamp)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(.top, 4)
+
+            Spacer()
+        }
+        .padding(.vertical, 8)
+        .padding(.trailing, 16)
+        .padding(.leading, 8) // Reduced leading to account for the unread dot
+        .background(notification.isRead ? Color.clear : Color.blue.opacity(0.05))
+    }
+
+    private var fallbackAvatar: some View {
+        Circle()
+            .fill(Color.gray.opacity(0.3))
+            .frame(width: 40, height: 40)
+            .overlay(
+                Text(String(notification.actorName.prefix(1)).uppercased())
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+            )
+    }
+
+    @ViewBuilder
+    private var typeIcon: some View {
+        switch notification.type.lowercased() {
+        case "like":
+            Image(systemName: "heart.fill")
+                .foregroundColor(.red)
+        case "comment":
+            Image(systemName: "bubble.right.fill")
+                .foregroundColor(.blue)
+        case "follow":
+            Image(systemName: "person.badge.plus.fill")
+                .foregroundColor(.green)
+        case "mention":
+            Image(systemName: "at")
+                .foregroundColor(.purple)
+        default:
+            Image(systemName: "bell.fill")
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Notifications/NotificationsView.swift
+++ b/iosApp/iosApp/Features/Notifications/NotificationsView.swift
@@ -2,16 +2,84 @@ import SwiftUI
 
 struct NotificationsView: View {
     @EnvironmentObject var navigator: AppNavigator
+    @StateObject private var viewModel = DependencyContainer.shared.makeNotificationsViewModel()
+    @State private var hasInitialFetch = false
 
     var body: some View {
         NavigationStack(path: $navigator.notificationsPath) {
-            VStack {
-                Text("Your Notifications")
-                    .font(.title)
-                    .fontWeight(.bold)
-                Spacer()
+            ZStack {
+                if viewModel.isLoading && viewModel.notifications.isEmpty {
+                    ProgressView("Loading notifications...")
+                } else if let errorMessage = viewModel.errorMessage, viewModel.notifications.isEmpty {
+                    VStack(spacing: 16) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.largeTitle)
+                            .foregroundColor(.red)
+                        Text("Error")
+                            .font(.headline)
+                        Text(errorMessage)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                        Button("Retry") {
+                            Task {
+                                await viewModel.loadNotifications()
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .padding()
+                } else if viewModel.notifications.isEmpty {
+                    VStack(spacing: 16) {
+                        Image(systemName: "bell.slash")
+                            .font(.largeTitle)
+                            .foregroundColor(.secondary)
+                        Text("No Notifications")
+                            .font(.headline)
+                        Text("You're all caught up! New notifications will appear here.")
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding()
+                } else {
+                    List {
+                        ForEach(viewModel.notifications) { notification in
+                            NotificationRowView(notification: notification)
+                                .listRowInsets(EdgeInsets())
+                                .listRowSeparator(.hidden)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    if !notification.isRead {
+                                        viewModel.markAsRead(notification.id)
+                                    }
+                                    // Optionally handle navigation based on notification.targetId here
+                                }
+                        }
+                    }
+                    .listStyle(.plain)
+                    .refreshable {
+                        await viewModel.loadNotifications()
+                    }
+                }
             }
             .navigationTitle("Notifications")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if !viewModel.notifications.isEmpty {
+                        Button("Mark all as read") {
+                            viewModel.markAllAsRead()
+                        }
+                        .font(.subheadline)
+                    }
+                }
+            }
+            .onAppear {
+                if !hasInitialFetch {
+                    hasInitialFetch = true
+                    Task {
+                        await viewModel.loadNotifications()
+                    }
+                }
+            }
         }
     }
 }

--- a/iosApp/iosApp/Features/Notifications/NotificationsViewModel.swift
+++ b/iosApp/iosApp/Features/Notifications/NotificationsViewModel.swift
@@ -1,0 +1,127 @@
+import Foundation
+import shared
+import Combine
+
+struct NotificationItem: Identifiable, Hashable {
+    let id: String
+    let type: String
+    let actorId: String?
+    let actorName: String
+    let actorAvatar: String?
+    let message: String
+    let timestamp: String
+    let isRead: Bool
+    let targetId: String?
+}
+
+@MainActor
+final class NotificationsViewModel: ObservableObject {
+    @Published var notifications: [NotificationItem] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String? = nil
+
+    private let getNotificationsUseCase = KMPHelper.sharedHelper.getNotificationsUseCase
+    private let markNotificationAsReadUseCase = KMPHelper.sharedHelper.markNotificationAsReadUseCase
+    private let subscribeToNotificationsUseCase = KMPHelper.sharedHelper.subscribeToNotificationsUseCase
+
+    private var loadTask: Task<Void, Never>?
+
+    init() {}
+
+    func loadNotifications() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            for try await result in getNotificationsUseCase.invoke() {
+                if let data = result.getOrNull() as? [shared.Notification] {
+                    self.notifications = data.map { self.mapDomainToUI($0) }
+                } else if let error = result.exceptionOrNull() {
+                    self.errorMessage = error.message ?? "Failed to fetch notifications"
+                }
+                self.isLoading = false
+            }
+        } catch {
+            self.errorMessage = error.localizedDescription
+            self.isLoading = false
+        }
+    }
+
+    func markAsRead(_ id: String) {
+        if let index = notifications.firstIndex(where: { $0.id == id }) {
+            notifications[index] = NotificationItem(
+                id: notifications[index].id,
+                type: notifications[index].type,
+                actorId: notifications[index].actorId,
+                actorName: notifications[index].actorName,
+                actorAvatar: notifications[index].actorAvatar,
+                message: notifications[index].message,
+                timestamp: notifications[index].timestamp,
+                isRead: true,
+                targetId: notifications[index].targetId
+            )
+        }
+
+        Task {
+            do {
+                try await markNotificationAsReadUseCase.invoke(notificationId: id)
+            } catch {
+                // Revert optimistic update on failure
+                if let index = notifications.firstIndex(where: { $0.id == id }) {
+                    notifications[index] = NotificationItem(
+                        id: notifications[index].id,
+                        type: notifications[index].type,
+                        actorId: notifications[index].actorId,
+                        actorName: notifications[index].actorName,
+                        actorAvatar: notifications[index].actorAvatar,
+                        message: notifications[index].message,
+                        timestamp: notifications[index].timestamp,
+                        isRead: false,
+                        targetId: notifications[index].targetId
+                    )
+                }
+                self.errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func markAllAsRead() {
+        let unreadNotifications = notifications.filter { !$0.isRead }
+        for notification in unreadNotifications {
+            markAsRead(notification.id)
+        }
+    }
+
+    private func mapDomainToUI(_ notification: shared.Notification) -> NotificationItem {
+        let messageText: String
+        if notification.messageType == .custom, let message = notification.message {
+            messageText = message
+        } else {
+            messageText = "You have a new notification"
+        }
+
+        let actorNameText = notification.actorName ?? "Someone"
+
+        // Simple relative time approximation
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var relativeTime = notification.timestamp
+        if let date = formatter.date(from: notification.timestamp) ?? ISO8601DateFormatter().date(from: notification.timestamp) {
+            let relativeFormatter = RelativeDateTimeFormatter()
+            relativeFormatter.unitsStyle = .short
+            relativeTime = relativeFormatter.localizedString(for: date, relativeTo: Date())
+        }
+
+        return NotificationItem(
+            id: notification.id,
+            type: notification.type,
+            actorId: notification.actorId,
+            actorName: actorNameText,
+            actorAvatar: notification.actorAvatar,
+            message: messageText,
+            timestamp: relativeTime,
+            isRead: notification.isRead,
+            targetId: notification.targetId
+        )
+    }
+}


### PR DESCRIPTION
This submission implements the complete iOS Notifications feature, bridging the gap between the shared Kotlin Multiplatform domain logic and the iOS SwiftUI interface.

Changes include:
1. **Dependency Injection:** Exposed `GetNotificationsUseCase`, `MarkNotificationAsReadUseCase`, and `SubscribeToNotificationsUseCase` in `KMPHelper`. Added a factory method for the ViewModel in `DependencyContainer`.
2. **ViewModel (`NotificationsViewModel`):** Created an `@MainActor` ViewModel that observes the KMP UseCases via `for try await` loops to collect the Kotlin flows, maps domain entities to `NotificationItem` presentation models, and handles optimistic updates for the "mark as read" feature.
3. **UI Components:**
   - Added `NotificationRowView` to display individual notifications with dynamic icons based on type, fallback avatars, and relative timestamps.
   - Fully implemented `NotificationsView` to handle the empty state, error states, and a `.refreshable` list. Added a toolbar action to "Mark all as read".

---
*PR created automatically by Jules for task [17719680806618092623](https://jules.google.com/task/17719680806618092623) started by @TheRealAshik*