### PR TITLE
Implement backend schema and shared logic for nested comments

### DIFF
--- a/desktop/src/jvmMain/kotlin/Main.kt
+++ b/desktop/src/jvmMain/kotlin/Main.kt
@@ -14,6 +14,7 @@ import com.synapse.social.studioasinc.shared.di.storageModule
 import com.synapse.social.studioasinc.shared.di.presenceModule
 import com.synapse.social.studioasinc.desktop.di.desktopModule
 import com.synapse.social.studioasinc.shared.core.network.SupabaseClient
+import com.synapse.social.studioasinc.shared.di.commentModule
 import com.synapse.social.studioasinc.shared.domain.model.auth.AuthSessionStatus
 import com.synapse.social.studioasinc.shared.domain.repository.AuthRepository
 import org.koin.core.context.startKoin

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/dto/CommentDto.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/dto/CommentDto.kt
@@ -1,0 +1,18 @@
+package com.synapse.social.studioasinc.shared.data.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CommentDto(
+    @SerialName("id") val id: String,
+    @SerialName("post_id") val postId: String,
+    @SerialName("author_id") val authorId: String,
+    @SerialName("parent_id") val parentId: String? = null,
+    @SerialName("content") val content: String,
+    @SerialName("media_url") val mediaUrl: String? = null,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String,
+    @SerialName("likes_count") val likesCount: Int = 0,
+    @SerialName("replies_count") val repliesCount: Int = 0
+)

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/dto/CommentDto.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/dto/CommentDto.kt
@@ -14,5 +14,14 @@ data class CommentDto(
     @SerialName("created_at") val createdAt: String,
     @SerialName("updated_at") val updatedAt: String,
     @SerialName("likes_count") val likesCount: Int = 0,
-    @SerialName("replies_count") val repliesCount: Int = 0
+    @SerialName("replies_count") val repliesCount: Int = 0,
+    @SerialName("is_deleted") val isDeleted: Boolean = false,
+    @SerialName("deleted_at") val deletedAt: String? = null,
+    @SerialName("author") val author: CommentAuthorDto? = null
+)
+
+@Serializable
+data class CommentAuthorDto(
+    @SerialName("username") val username: String? = null,
+    @SerialName("avatar") val avatarUrl: String? = null
 )

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/mapper/CommentMapper.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/mapper/CommentMapper.kt
@@ -10,7 +10,7 @@ object CommentMapper {
             id = dto.id,
             postId = dto.postId,
             authorId = dto.authorId,
-            text = dto.content,
+            text = if (dto.isDeleted) "This comment was deleted" else dto.content,
             timestamp = try {
                 Instant.parse(dto.createdAt).toEpochMilliseconds()
             } catch (e: Exception) {
@@ -19,7 +19,9 @@ object CommentMapper {
             likesCount = dto.likesCount,
             repliesCount = dto.repliesCount,
             parentCommentId = dto.parentId,
-            isDeleted = false
+            isDeleted = dto.isDeleted,
+            username = dto.author?.username,
+            avatarUrl = dto.author?.avatarUrl
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/mapper/CommentMapper.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/mapper/CommentMapper.kt
@@ -1,0 +1,22 @@
+package com.synapse.social.studioasinc.shared.data.mapper
+
+import com.synapse.social.studioasinc.shared.data.dto.CommentDto
+import com.synapse.social.studioasinc.shared.domain.model.Comment
+
+object CommentMapper {
+    fun toDomain(dto: CommentDto): Comment {
+        return Comment(
+            id = dto.id,
+            postId = dto.postId,
+            authorId = dto.authorId,
+            text = dto.content,
+            timestamp = 0L, // In a real app, parse from dto.createdAt
+            likesCount = dto.likesCount,
+            repliesCount = dto.repliesCount,
+            parentCommentId = dto.parentId,
+            isDeleted = false
+        )
+    }
+
+    fun toDomainList(dtos: List<CommentDto>): List<Comment> = dtos.map { toDomain(it) }
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/mapper/CommentMapper.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/mapper/CommentMapper.kt
@@ -2,6 +2,7 @@ package com.synapse.social.studioasinc.shared.data.mapper
 
 import com.synapse.social.studioasinc.shared.data.dto.CommentDto
 import com.synapse.social.studioasinc.shared.domain.model.Comment
+import kotlinx.datetime.Instant
 
 object CommentMapper {
     fun toDomain(dto: CommentDto): Comment {
@@ -10,7 +11,11 @@ object CommentMapper {
             postId = dto.postId,
             authorId = dto.authorId,
             text = dto.content,
-            timestamp = 0L, // In a real app, parse from dto.createdAt
+            timestamp = try {
+                Instant.parse(dto.createdAt).toEpochMilliseconds()
+            } catch (e: Exception) {
+                0L
+            },
             likesCount = dto.likesCount,
             repliesCount = dto.repliesCount,
             parentCommentId = dto.parentId,

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseCommentRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseCommentRepository.kt
@@ -1,0 +1,61 @@
+package com.synapse.social.studioasinc.shared.data.repository
+
+import com.synapse.social.studioasinc.shared.data.dto.CommentDto
+import com.synapse.social.studioasinc.shared.data.mapper.CommentMapper
+import com.synapse.social.studioasinc.shared.domain.model.Comment
+import com.synapse.social.studioasinc.shared.domain.repository.CommentRepository
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Order
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+class SupabaseCommentRepository(
+    private val supabaseClient: SupabaseClient
+) : CommentRepository {
+
+    override suspend fun getComments(postId: String, parentId: String?): Result<List<Comment>> = withContext(Dispatchers.IO) {
+        runCatching {
+            val response = supabaseClient.from("comments").select {
+                filter {
+                    eq("post_id", postId)
+                    if (parentId == null) {
+                        filter("parent_id", "is", "null")
+                    } else {
+                        eq("parent_id", parentId)
+                    }
+                }
+                order("created_at", Order.ASCENDING)
+            }.decodeList<CommentDto>()
+            CommentMapper.toDomainList(response)
+        }
+    }
+
+    override suspend fun addComment(postId: String, content: String, parentId: String?, mediaUrl: String?): Result<Comment> = withContext(Dispatchers.IO) {
+        runCatching {
+            val userId = supabaseClient.auth.currentUserOrNull()?.id ?: throw Exception("User not authenticated")
+            val commentDto = supabaseClient.from("comments").insert(
+                mapOf(
+                    "post_id" to postId,
+                    "author_id" to userId,
+                    "parent_id" to parentId,
+                    "content" to content,
+                    "media_url" to mediaUrl
+                )
+            ) {
+                select()
+            }.decodeSingle<CommentDto>()
+            CommentMapper.toDomain(commentDto)
+        }
+    }
+
+    override suspend fun deleteComment(commentId: String): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            supabaseClient.from("comments").delete {
+                filter { eq("id", commentId) }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseCommentRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseCommentRepository.kt
@@ -7,11 +7,13 @@ import com.synapse.social.studioasinc.shared.domain.repository.CommentRepository
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Columns
 import io.github.jan.supabase.postgrest.query.Order
 import io.github.jan.supabase.postgrest.query.filter.FilterOperator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 
 class SupabaseCommentRepository(
     private val supabaseClient: SupabaseClient
@@ -19,7 +21,9 @@ class SupabaseCommentRepository(
 
     override suspend fun getComments(postId: String, parentId: String?): Result<List<Comment>> = withContext(Dispatchers.IO) {
         runCatching {
-            val response = supabaseClient.from("comments").select {
+            val response = supabaseClient.from("comments").select(
+                columns = Columns.raw("*, author:users(username, avatar)")
+            ) {
                 filter {
                     eq("post_id", postId)
                     if (parentId == null) {
@@ -46,7 +50,7 @@ class SupabaseCommentRepository(
                     "media_url" to mediaUrl
                 )
             ) {
-                select()
+                select(columns = Columns.raw("*, author:users(username, avatar)"))
             }.decodeSingle<CommentDto>()
             CommentMapper.toDomain(commentDto)
         }
@@ -54,7 +58,13 @@ class SupabaseCommentRepository(
 
     override suspend fun deleteComment(commentId: String): Result<Unit> = withContext(Dispatchers.IO) {
         runCatching {
-            supabaseClient.from("comments").delete {
+            // Soft delete
+            supabaseClient.from("comments").update(
+                mapOf(
+                    "is_deleted" to true,
+                    "deleted_at" to Clock.System.now().toString()
+                )
+            ) {
                 filter { eq("id", commentId) }
             }
             Unit

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseCommentRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseCommentRepository.kt
@@ -8,6 +8,7 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.postgrest.from
 import io.github.jan.supabase.postgrest.query.Order
+import io.github.jan.supabase.postgrest.query.filter.FilterOperator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
@@ -22,7 +23,7 @@ class SupabaseCommentRepository(
                 filter {
                     eq("post_id", postId)
                     if (parentId == null) {
-                        filter("parent_id", "is", "null")
+                        filter("parent_id", FilterOperator.IS, "null")
                     } else {
                         eq("parent_id", parentId)
                     }
@@ -56,6 +57,7 @@ class SupabaseCommentRepository(
             supabaseClient.from("comments").delete {
                 filter { eq("id", commentId) }
             }
+            Unit
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/di/CommentModule.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/di/CommentModule.kt
@@ -1,0 +1,13 @@
+package com.synapse.social.studioasinc.shared.di
+
+import com.synapse.social.studioasinc.shared.data.repository.SupabaseCommentRepository
+import com.synapse.social.studioasinc.shared.domain.repository.CommentRepository
+import com.synapse.social.studioasinc.shared.domain.usecase.comment.AddCommentUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.comment.GetCommentsUseCase
+import org.koin.dsl.module
+
+val commentModule = module {
+    single<CommentRepository> { SupabaseCommentRepository(get()) }
+    factory { GetCommentsUseCase(get()) }
+    factory { AddCommentUseCase(get()) }
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/repository/CommentRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/repository/CommentRepository.kt
@@ -1,0 +1,9 @@
+package com.synapse.social.studioasinc.shared.domain.repository
+
+import com.synapse.social.studioasinc.shared.domain.model.Comment
+
+interface CommentRepository {
+    suspend fun getComments(postId: String, parentId: String? = null): Result<List<Comment>>
+    suspend fun addComment(postId: String, content: String, parentId: String?, mediaUrl: String? = null): Result<Comment>
+    suspend fun deleteComment(commentId: String): Result<Unit>
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/comment/AddCommentUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/comment/AddCommentUseCase.kt
@@ -1,0 +1,10 @@
+package com.synapse.social.studioasinc.shared.domain.usecase.comment
+
+import com.synapse.social.studioasinc.shared.domain.model.Comment
+import com.synapse.social.studioasinc.shared.domain.repository.CommentRepository
+
+class AddCommentUseCase(private val repository: CommentRepository) {
+    suspend operator fun invoke(postId: String, content: String, parentId: String?, mediaUrl: String? = null): Result<Comment> {
+        return repository.addComment(postId, content, parentId, mediaUrl)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/comment/GetCommentsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/comment/GetCommentsUseCase.kt
@@ -1,0 +1,10 @@
+package com.synapse.social.studioasinc.shared.domain.usecase.comment
+
+import com.synapse.social.studioasinc.shared.domain.model.Comment
+import com.synapse.social.studioasinc.shared.domain.repository.CommentRepository
+
+class GetCommentsUseCase(private val repository: CommentRepository) {
+    suspend operator fun invoke(postId: String, parentId: String? = null): Result<List<Comment>> {
+        return repository.getComments(postId, parentId)
+    }
+}

--- a/shared/src/iosMain/kotlin/com/synapse/social/studioasinc/shared/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/synapse/social/studioasinc/shared/di/KoinHelper.kt
@@ -10,7 +10,11 @@ import com.synapse.social.studioasinc.shared.domain.usecase.blocking.UnblockUser
 import com.synapse.social.studioasinc.shared.domain.usecase.blocking.GetBlockedUsersUseCase
 import com.synapse.social.studioasinc.shared.domain.model.User
 import com.synapse.social.studioasinc.shared.domain.model.BlockedUser
+import com.synapse.social.studioasinc.shared.domain.model.Comment
 import com.synapse.social.studioasinc.shared.domain.repository.AuthRepository
+import com.synapse.social.studioasinc.shared.domain.repository.CommentRepository
+import com.synapse.social.studioasinc.shared.domain.usecase.comment.AddCommentUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.comment.GetCommentsUseCase
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -21,15 +25,28 @@ object IOSDependencies : KoinComponent {
     fun getUserRepository() = UserRepositoryImpl(database, com.synapse.social.studioasinc.shared.data.datasource.SupabaseUserDataSource(SupabaseClient.client))
     fun getUserPreferencesRepository() = UserPreferencesRepositoryImpl(SupabaseClient.client)
 
-    // Inject StorageRepository from Koin
+    // Inject repositories from Koin
     fun getAuthRepository(): AuthRepository = getKoin().get()
     fun getStorageRepository(): com.synapse.social.studioasinc.shared.domain.repository.StorageRepository = getKoin().get()
+    fun getCommentRepository(): CommentRepository = getKoin().get()
 
     // Create use cases on demand
     private fun getProfileUseCase() = GetUserProfileUseCase(getUserRepository())
     private fun getUpdateProfileUseCase() = UpdateProfileUseCase(getUserRepository())
+    private fun getCommentsUseCase() = GetCommentsUseCase(getCommentRepository())
+    private fun getAddCommentUseCase() = AddCommentUseCase(getCommentRepository())
 
     // iOS-specific wrappers that unwrap kotlin.Result for Swift async throws bridging
+    @Throws(Exception::class)
+    suspend fun getComments(postId: String, parentId: String? = null): List<Comment> {
+        return getCommentsUseCase()(postId, parentId).getOrThrow()
+    }
+
+    @Throws(Exception::class)
+    suspend fun addComment(postId: String, content: String, parentId: String?, mediaUrl: String? = null): Comment {
+        return getAddCommentUseCase()(postId, content, parentId, mediaUrl).getOrThrow()
+    }
+
     @Throws(Exception::class)
     suspend fun fetchUserProfile(uid: String): User? {
         val result = getProfileUseCase()(uid)

--- a/supabase/migrations/20240520000000_create_comments_table.sql
+++ b/supabase/migrations/20240520000000_create_comments_table.sql
@@ -10,9 +10,15 @@ CREATE TABLE comments (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     likes_count INTEGER NOT NULL DEFAULT 0,
     replies_count INTEGER NOT NULL DEFAULT 0,
+    is_deleted BOOLEAN NOT NULL DEFAULT false,
+    deleted_at TIMESTAMPTZ,
 
-    FOREIGN KEY (parent_id) REFERENCES comments(id) ON DELETE CASCADE
+    FOREIGN KEY (parent_id) REFERENCES comments(id)
 );
+
+-- Add indexes for performance
+CREATE INDEX idx_comments_post_id ON comments(post_id);
+CREATE INDEX idx_comments_parent_id ON comments(parent_id);
 
 -- Enable RLS
 ALTER TABLE comments ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20240520000000_create_comments_table.sql
+++ b/supabase/migrations/20240520000000_create_comments_table.sql
@@ -1,0 +1,49 @@
+-- Create comments table
+CREATE TABLE comments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    post_id UUID NOT NULL, -- The root post
+    author_id UUID NOT NULL, -- The author of the comment
+    parent_id UUID, -- The parent comment (null if top-level)
+    content TEXT NOT NULL,
+    media_url TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    likes_count INTEGER NOT NULL DEFAULT 0,
+    replies_count INTEGER NOT NULL DEFAULT 0,
+
+    FOREIGN KEY (parent_id) REFERENCES comments(id) ON DELETE CASCADE
+);
+
+-- Enable RLS
+ALTER TABLE comments ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+CREATE POLICY "Comments are viewable by everyone"
+    ON comments FOR SELECT
+    USING (true);
+
+CREATE POLICY "Users can insert their own comments"
+    ON comments FOR INSERT
+    WITH CHECK (auth.uid() = author_id);
+
+CREATE POLICY "Users can update their own comments"
+    ON comments FOR UPDATE
+    USING (auth.uid() = author_id);
+
+CREATE POLICY "Users can delete their own comments"
+    ON comments FOR DELETE
+    USING (auth.uid() = author_id);
+
+-- Trigger for updated_at
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_comments_updated_at
+    BEFORE UPDATE ON comments
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();

--- a/web/src/wasmJsMain/kotlin/Main.kt
+++ b/web/src/wasmJsMain/kotlin/Main.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.CanvasBasedWindow
+import com.synapse.social.studioasinc.shared.di.commentModule
 import com.synapse.social.studioasinc.shared.di.storageModule
 import com.synapse.social.studioasinc.web.di.webModule
 import com.synapse.social.studioasinc.web.ui.WebAuthScreen
@@ -19,7 +20,7 @@ enum class WebScreen {
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     startKoin {
-        modules(storageModule, webModule)
+        modules(storageModule, commentModule, webModule)
     }
 
     CanvasBasedWindow(canvasElementId = "ComposeTarget") {


### PR DESCRIPTION
Implemented the backend schema on Supabase by creating a new `comments` table with `parent_id` for nested threading. Developed the shared logic in the KMP module, including DTOs, mappers, repositories, and use cases. These are now exposed to both Android and iOS platforms via Koin and a dependency bridge, enabling the next phase of UI implementation for X-style nested comment threading.

Fixes #82

---
*PR created automatically by Jules for task [7148783362614004342](https://jules.google.com/task/7148783362614004342) started by @TheRealAshik*