### PR TITLE
🧹 Remove unused QrCodeScanner import in SearchScreen

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/search/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/search/search/SearchScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.ui.res.stringResource


### PR DESCRIPTION
This PR removes an unused import of `QrCodeScanner` from `SearchScreen.kt`. 

### 🎯 What:
Removed `import androidx.compose.material.icons.filled.QrCodeScanner` from `app/src/main/kotlin/com/synapse/social/studioasinc/feature/search/search/SearchScreen.kt`.

### 💡 Why:
Removing unused imports improves code maintainability and readability by keeping the codebase clean.

### ✅ Verification:
- Verified that `QrCodeScanner` is not used anywhere else in the file using `grep`.
- Confirmed that other icons like `Search`, `Close`, and `Mic` are still correctly imported and used.
- Code review confirmed the change is safe and correct.

### ✨ Result:
Improved code health in the search feature.

---
*PR created automatically by Jules for task [1845857609516574654](https://jules.google.com/task/1845857609516574654) started by @TheRealAshik*