### PR TITLE
🔒 [security fix] Encrypt Local PreKey Storage

### DIFF
--- a/shared/src/androidMain/kotlin/com/synapse/social/studioasinc/shared/data/crypto/AndroidSignalProtocolStore.kt
+++ b/shared/src/androidMain/kotlin/com/synapse/social/studioasinc/shared/data/crypto/AndroidSignalProtocolStore.kt
@@ -1,7 +1,10 @@
 package com.synapse.social.studioasinc.shared.data.crypto
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.util.Base64
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import org.whispersystems.libsignal.IdentityKey
 import org.whispersystems.libsignal.IdentityKeyPair
 import org.whispersystems.libsignal.SignalProtocolAddress
@@ -16,7 +19,19 @@ import org.whispersystems.libsignal.state.SignedPreKeyStore
 
 class AndroidSignalProtocolStore(context: Context) : SignalProtocolStore {
 
-    private val prefs = context.getSharedPreferences("signal_store", Context.MODE_PRIVATE)
+    private val prefs: SharedPreferences by lazy {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        EncryptedSharedPreferences.create(
+            context,
+            "signal_store_secure",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
 
     // --- IdentityKeyStore ---
 


### PR DESCRIPTION
This PR fixes a security vulnerability in the Android Signal protocol implementation where sensitive keys and session records were stored in plain text.

🎯 **What:** The vulnerability involved using unencrypted `SharedPreferences` to store `PreKeys`, `IdentityKeys`, and `SessionRecords`.
⚠️ **Risk:** An attacker with physical access to the device or through a backup could extract these keys, potentially compromising the end-to-end encryption and allowing for message decryption or impersonation.
🛡️ **Solution:** Implemented `EncryptedSharedPreferences` using the Jetpack Security library. This ensures that all data written to disk is encrypted using keys managed by the Android Keystore system. The implementation uses `AES256_SIV` for key encryption and `AES256_GCM` for value encryption, following modern security best practices.

---
*PR created automatically by Jules for task [6390492037599639792](https://jules.google.com/task/6390492037599639792) started by @TheRealAshik*