### PR TITLE
fix: Create Group button always disabled — user list never loads

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/CreateGroupScreen.kt
@@ -40,6 +40,7 @@ fun CreateGroupScreen(
 ) {
     val users by viewModel.users.collectAsStateWithLifecycle()
     val selectedUsers by viewModel.selectedUsers.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     val groupName by viewModel.groupName.collectAsStateWithLifecycle()
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
@@ -109,8 +110,19 @@ fun CreateGroupScreen(
                 label = { Text(stringResource(R.string.group_name_label)) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(Spacing.Medium),
+                    .padding(horizontal = Spacing.Medium, vertical = Spacing.Small),
                 singleLine = true
+            )
+
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { viewModel.onSearchQueryChange(it) },
+                label = { Text(stringResource(R.string.search_by_username_hint)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacing.Medium, vertical = Spacing.Small),
+                singleLine = true,
+                placeholder = { Text(stringResource(R.string.search_hint)) }
             )
 
             Text(

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/CreateGroupViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/CreateGroupViewModel.kt
@@ -4,8 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.synapse.social.studioasinc.shared.domain.model.User
 import com.synapse.social.studioasinc.shared.domain.repository.ChatRepository
-import com.synapse.social.studioasinc.shared.domain.repository.UserRepository
+import com.synapse.social.studioasinc.shared.domain.usecase.follow.GetFollowingUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.user.SearchUsersUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,11 +18,19 @@ import javax.inject.Inject
 @HiltViewModel
 class CreateGroupViewModel @Inject constructor(
     private val chatRepository: ChatRepository,
-    private val userRepository: UserRepository
+    private val searchUsersUseCase: SearchUsersUseCase,
+    private val getFollowingUseCase: GetFollowingUseCase
 ) : ViewModel() {
 
     private val _users = MutableStateFlow<List<User>>(emptyList())
     val users: StateFlow<List<User>> = _users.asStateFlow()
+
+    private var _initialUsers = emptyList<User>()
+
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    private var searchJob: Job? = null
 
     private val _selectedUsers = MutableStateFlow<List<User>>(emptyList())
     val selectedUsers: StateFlow<List<User>> = _selectedUsers.asStateFlow()
@@ -43,17 +54,46 @@ class CreateGroupViewModel @Inject constructor(
     private fun loadUsers() {
         viewModelScope.launch {
             _isLoading.value = true
-            // Load followers/following or all users. Just mock or use an existing use case.
-            // Let's use search users or just load some users.
             try {
-                // Dummy logic for now since getting all users might need a specific usecase
-                // We'll just assume userRepository.getSuggestedUsers or similar
-                val currentUserId = chatRepository.getCurrentUserId() ?: return@launch
-                // Let's just use search to get some users since getFollowers doesn't exist
-                userRepository.searchUsers("").onSuccess { result ->
+                val currentUserId = chatRepository.getCurrentUserId()
+                if (currentUserId == null) {
+                    _error.value = "User not authenticated"
+                    return@launch
+                }
+                getFollowingUseCase(currentUserId).onSuccess { result ->
+                    _initialUsers = result
+                    if (_searchQuery.value.isBlank()) {
+                        _users.value = result
+                    }
+                }.onFailure {
+                    _error.value = "Failed to load suggested users"
+                }
+            } catch (e: Exception) {
+                _error.value = e.message
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    fun onSearchQueryChange(query: String) {
+        _searchQuery.value = query
+        searchJob?.cancel()
+
+        if (query.isBlank()) {
+            _users.value = _initialUsers
+            _isLoading.value = false
+            return
+        }
+
+        searchJob = viewModelScope.launch {
+            try {
+                delay(300) // Debounce
+                _isLoading.value = true
+                searchUsersUseCase(query).onSuccess { result ->
                     _users.value = result
                 }.onFailure {
-                    _error.value = "Failed to load users"
+                    _error.value = "Search failed"
                 }
             } catch (e: Exception) {
                 _error.value = e.message


### PR DESCRIPTION
The "Create Group" button was permanently disabled because the user list failed to populate, preventing member selection. This was caused by `CreateGroupViewModel` calling `userRepository.searchUsers("")`, which returns an empty list for blank queries.

I have fixed this by:
1.  **Initial Population**: Loading the list of users the current user is following when the screen opens, providing immediate options for group members.
2.  **Search Functionality**: Adding a search bar to the screen and implementing debounced search logic in the ViewModel, allowing users to find any member on the platform.
3.  **Clean Architecture Compliance**: Refactoring the ViewModel to use `GetFollowingUseCase` and `SearchUsersUseCase` instead of repositories directly, adhering to the project's architectural standards.
4.  **Robust State Management**: Ensuring the `isLoading` state is reliably cleared using `try-finally` blocks.

Fixes #106

---
*PR created automatically by Jules for task [11313530848942043060](https://jules.google.com/task/11313530848942043060) started by @TheRealAshik*