### PR TITLE
feat: Add 3D pop animation to like button

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/AnimatedCounter.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/AnimatedCounter.kt
@@ -1,0 +1,35 @@
+package com.synapse.social.studioasinc.feature.shared.components
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun AnimatedCounter(
+    count: Int,
+    modifier: Modifier = Modifier,
+    content: @Composable (Int) -> Unit
+) {
+    AnimatedContent(
+        targetState = count,
+        modifier = modifier,
+        transitionSpec = {
+            if (targetState > initialState) {
+                (slideInVertically { height -> height } + fadeIn()).togetherWith(
+                    slideOutVertically { height -> -height } + fadeOut())
+            } else {
+                (slideInVertically { height -> -height } + fadeIn()).togetherWith(
+                    slideOutVertically { height -> height } + fadeOut())
+            }.using(SizeTransform(clip = false))
+        },
+        label = "AnimatedCounter"
+    ) { targetCount ->
+        content(targetCount)
+    }
+}

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostInteractionBar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostInteractionBar.kt
@@ -39,19 +39,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.graphicsLayer
 import kotlinx.coroutines.launch
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import com.synapse.social.studioasinc.feature.shared.components.AnimatedCounter
 import com.synapse.social.studioasinc.feature.shared.theme.InteractionIconDefault
 import com.synapse.social.studioasinc.feature.shared.theme.InteractionLikeActive
 import com.synapse.social.studioasinc.feature.shared.theme.InteractionRepostActive
@@ -226,6 +220,10 @@ fun PostInteractionBar(
                         rotX.animateTo(-15f, tween(150))
                         rotX.animateTo(0f, tween(150))
                     }
+                } else {
+                    scale.snapTo(1f)
+                    rotY.snapTo(0f)
+                    rotX.snapTo(0f)
                 }
             }
 
@@ -259,19 +257,7 @@ fun PostInteractionBar(
                 )
                 if (likeCount > 0 && !hideLikeCount) {
                     Spacer(modifier = Modifier.width(Spacing.ExtraSmall))
-                    AnimatedContent(
-                        targetState = likeCount,
-                        transitionSpec = {
-                            if (targetState > initialState) {
-                                (slideInVertically { height -> height } + fadeIn()).togetherWith(
-                                    slideOutVertically { height -> -height } + fadeOut())
-                            } else {
-                                (slideInVertically { height -> -height } + fadeIn()).togetherWith(
-                                    slideOutVertically { height -> height } + fadeOut())
-                            }.using(SizeTransform(clip = false))
-                        },
-                        label = "LikeCountAnimation"
-                    ) { targetCount ->
+                    AnimatedCounter(count = likeCount) { targetCount ->
                         Text(
                             text = formatCount(targetCount),
                             style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostInteractionBar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostInteractionBar.kt
@@ -39,7 +39,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.graphicsLayer
 import kotlinx.coroutines.launch
@@ -252,12 +259,26 @@ fun PostInteractionBar(
                 )
                 if (likeCount > 0 && !hideLikeCount) {
                     Spacer(modifier = Modifier.width(Spacing.ExtraSmall))
-                    Text(
-                        text = formatCount(likeCount),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = if (isLiked) likeActiveColor else iconColor,
-                        fontWeight = if (isLiked) FontWeight.Bold else FontWeight.Normal
-                    )
+                    AnimatedContent(
+                        targetState = likeCount,
+                        transitionSpec = {
+                            if (targetState > initialState) {
+                                (slideInVertically { height -> height } + fadeIn()).togetherWith(
+                                    slideOutVertically { height -> -height } + fadeOut())
+                            } else {
+                                (slideInVertically { height -> -height } + fadeIn()).togetherWith(
+                                    slideOutVertically { height -> height } + fadeOut())
+                            }.using(SizeTransform(clip = false))
+                        },
+                        label = "LikeCountAnimation"
+                    ) { targetCount ->
+                        Text(
+                            text = formatCount(targetCount),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (isLiked) likeActiveColor else iconColor,
+                            fontWeight = if (isLiked) FontWeight.Bold else FontWeight.Normal
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostInteractionBar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostInteractionBar.kt
@@ -36,6 +36,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.graphics.graphicsLayer
+import kotlinx.coroutines.launch
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import com.synapse.social.studioasinc.feature.shared.theme.InteractionIconDefault
@@ -181,6 +188,40 @@ fun PostInteractionBar(
             }
 
             // Like
+            val scale = remember { Animatable(1f) }
+            val rotY = remember { Animatable(0f) }
+            val rotX = remember { Animatable(0f) }
+
+            LaunchedEffect(isLiked) {
+                if (isLiked) {
+                    scale.snapTo(1f)
+                    rotY.snapTo(0f)
+                    rotX.snapTo(0f)
+
+                    launch {
+                        scale.animateTo(
+                            targetValue = 1.4f,
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                        )
+                        scale.animateTo(
+                            targetValue = 1f,
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                        )
+                    }
+
+                    launch {
+                        rotY.animateTo(20f, tween(100))
+                        rotY.animateTo(-20f, tween(100))
+                        rotY.animateTo(0f, tween(100))
+                    }
+
+                    launch {
+                        rotX.animateTo(-15f, tween(150))
+                        rotX.animateTo(0f, tween(150))
+                    }
+                }
+            }
+
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
@@ -200,7 +241,14 @@ fun PostInteractionBar(
                         likeCount
                     ),
                     tint = if (isLiked) likeActiveColor else iconColor,
-                    modifier = Modifier.size(Sizes.IconMedium)
+                    modifier = Modifier
+                        .size(Sizes.IconMedium)
+                        .graphicsLayer {
+                            scaleX = scale.value
+                            scaleY = scale.value
+                            rotationY = rotY.value
+                            rotationX = rotX.value
+                        }
                 )
                 if (likeCount > 0 && !hideLikeCount) {
                     Spacer(modifier = Modifier.width(Spacing.ExtraSmall))


### PR DESCRIPTION
Added a 3D "pop" animation to the heart/favorite icon in `PostInteractionBar` that triggers every time the user likes a post.
The animation smoothly handles rapid clicks by resetting its state.

---
*PR created automatically by Jules for task [1896154359474798061](https://jules.google.com/task/1896154359474798061) started by @TheRealAshik*