### PR TITLE
Update copyright year and avatar fallbacks

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/Avatar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/Avatar.kt
@@ -44,7 +44,7 @@ fun CircularAvatar(
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = displayName?.firstOrNull { it.isLetterOrDigit() }?.uppercaseChar()?.toString() ?: displayName?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                text = displayName?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onPrimaryContainer
             )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/Avatar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/Avatar.kt
@@ -44,7 +44,7 @@ fun CircularAvatar(
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = displayName?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                text = displayName.let { name -> name?.firstOrNull { it.isLetterOrDigit() } ?: name?.firstOrNull() }?.uppercaseChar()?.toString() ?: "?",
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onPrimaryContainer
             )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/UserAvatar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/UserAvatar.kt
@@ -32,7 +32,7 @@ fun UserAvatar(
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = displayName?.firstOrNull { it.isLetterOrDigit() }?.uppercaseChar()?.toString() ?: displayName?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                text = displayName?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onPrimaryContainer
             )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/UserAvatar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/UserAvatar.kt
@@ -32,7 +32,7 @@ fun UserAvatar(
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = displayName?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                text = displayName.let { name -> name?.firstOrNull { it.isLetterOrDigit() } ?: name?.firstOrNull() }?.uppercaseChar()?.toString() ?: "?",
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onPrimaryContainer
             )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/management/StorySheets.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/management/StorySheets.kt
@@ -161,7 +161,7 @@ private fun ViewerListItem(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = viewer?.displayName?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                    text = viewer?.displayName.let { name -> name?.firstOrNull { it.isLetterOrDigit() } ?: name?.firstOrNull() }?.uppercaseChar()?.toString() ?: "?",
                     style = MaterialTheme.typography.titleMedium
                 )
             }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/management/StorySheets.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/management/StorySheets.kt
@@ -161,7 +161,7 @@ private fun ViewerListItem(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = viewer?.displayName?.firstOrNull()?.uppercase() ?: "?",
+                    text = viewer?.displayName?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
                     style = MaterialTheme.typography.titleMedium
                 )
             }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/viewer/StoryViewerScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/viewer/StoryViewerScreen.kt
@@ -152,7 +152,7 @@ fun StoryMediaContent(
     Box(modifier = Modifier.fillMaxSize()) {
         if (story.mediaType == StoryMediaType.VIDEO && story.mediaUrl != null) {
             VideoPlayer(
-                mediaUrl = story.mediaUrl ?: "",
+                mediaUrl = story.mediaUrl,
                 isPaused = isPaused,
                 onVideoReady = onVideoReady
             )
@@ -297,7 +297,7 @@ fun StoryUserHeader(
                 )
             } else {
                 Text(
-                    text = (user?.displayName ?: user?.username)?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                    text = (user?.displayName ?: user?.username).let { name -> name?.firstOrNull { it.isLetterOrDigit() } ?: name?.firstOrNull() }?.uppercaseChar()?.toString() ?: "?",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/viewer/StoryViewerScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/viewer/StoryViewerScreen.kt
@@ -297,7 +297,7 @@ fun StoryUserHeader(
                 )
             } else {
                 Text(
-                    text = (user?.displayName ?: user?.username ?: "?").take(1).uppercase(),
+                    text = (user?.displayName ?: user?.username)?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -758,7 +758,7 @@
     <string name="about_app_info">অ্যাপ তথ্য</string>
     <string name="about_version">ভার্সন</string>
     <string name="about_build">বিল্ড</string>
-    <string name="about_copyright">© ২০২৪ Synapse। সর্বস্বত্ব সংরক্ষিত।</string>
+    <string name="about_copyright">© ২০২৬ Synapse। সর্বস্বত্ব সংরক্ষিত।</string>
     <string name="about_section_legal">আইনি</string>
     <string name="about_terms">পরিষেবার শর্তাবলী</string>
     <string name="about_terms_subtitle">আমাদের শর্তাবলী পড়ুন</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -892,7 +892,7 @@ Please explain the following message from %3$s in detail, considering the contex
     <string name="about_app_info">App Information</string>
     <string name="about_version">Version</string>
     <string name="about_build">Build</string>
-    <string name="about_copyright">© 2024 Synapse. All rights reserved.</string>
+    <string name="about_copyright">© 2026 Synapse. All rights reserved.</string>
     <string name="about_section_legal">Legal</string>
     <string name="about_terms">Terms of Service</string>
     <string name="about_terms_subtitle">Read our terms and conditions</string>

--- a/iosApp/iosApp/MediaCreation/Views/MentionSuggestionView.swift
+++ b/iosApp/iosApp/MediaCreation/Views/MentionSuggestionView.swift
@@ -41,11 +41,7 @@ struct MentionSuggestionView: View {
                                         .fill(Color.gray.opacity(0.3))
                                         .frame(width: 40, height: 40)
                                         .overlay(
-                                            Text({ () -> String in
-                                                let nameToUse = user.displayName ?? user.username
-                                                guard let firstChar = nameToUse.first else { return "?" }
-                                                return String(firstChar).uppercased()
-                                            }())
+                                            Text(String((user.displayName ?? user.username).first ?? "?").uppercased())
                                                 .foregroundColor(.white)
                                         )
 

--- a/iosApp/iosApp/MediaCreation/Views/MentionSuggestionView.swift
+++ b/iosApp/iosApp/MediaCreation/Views/MentionSuggestionView.swift
@@ -41,7 +41,11 @@ struct MentionSuggestionView: View {
                                         .fill(Color.gray.opacity(0.3))
                                         .frame(width: 40, height: 40)
                                         .overlay(
-                                            Text(String(user.displayName?.prefix(1) ?? "?"))
+                                            Text({ () -> String in
+                                                let nameToUse = user.displayName ?? user.username
+                                                guard let firstChar = nameToUse.first else { return "?" }
+                                                return String(firstChar).uppercased()
+                                            }())
                                                 .foregroundColor(.white)
                                         )
 

--- a/iosApp/iosApp/Search/Views/DiscoveryFeedView.swift
+++ b/iosApp/iosApp/Search/Views/DiscoveryFeedView.swift
@@ -108,11 +108,7 @@ struct SuggestedUserCard: View {
                 .fill(Color.gray.opacity(0.3))
                 .frame(width: 60, height: 60)
                 .overlay(
-                    Text({ () -> String in
-                        let nameToUse = user.displayName ?? user.handle ?? ""
-                        guard let firstChar = nameToUse.first else { return "?" }
-                        return String(firstChar).uppercased()
-                    }())
+                    Text(String((user.displayName ?? user.handle)?.first ?? "?").uppercased())
                         .foregroundColor(.gray)
                         .font(.title3)
                 )

--- a/iosApp/iosApp/Search/Views/DiscoveryFeedView.swift
+++ b/iosApp/iosApp/Search/Views/DiscoveryFeedView.swift
@@ -108,7 +108,11 @@ struct SuggestedUserCard: View {
                 .fill(Color.gray.opacity(0.3))
                 .frame(width: 60, height: 60)
                 .overlay(
-                    Text(user.displayName?.prefix(1).uppercased() ?? user.handle?.prefix(1).uppercased() ?? "?")
+                    Text({ () -> String in
+                        let nameToUse = user.displayName ?? user.handle ?? ""
+                        guard let firstChar = nameToUse.first else { return "?" }
+                        return String(firstChar).uppercased()
+                    }())
                         .foregroundColor(.gray)
                         .font(.title3)
                 )

--- a/iosApp/iosApp/Search/Views/PostResultRow.swift
+++ b/iosApp/iosApp/Search/Views/PostResultRow.swift
@@ -13,11 +13,7 @@ struct PostResultRow: View {
                     .fill(Color.gray.opacity(0.3))
                     .frame(width: 40, height: 40)
                     .overlay(
-                        Text({ () -> String in
-                            let nameToUse = post.authorName ?? post.authorHandle ?? ""
-                            guard let firstChar = nameToUse.first else { return "?" }
-                            return String(firstChar).uppercased()
-                        }())
+                        Text(String((post.authorName ?? post.authorHandle)?.first ?? "?").uppercased())
                             .foregroundColor(.gray)
                             .font(.subheadline)
                     )

--- a/iosApp/iosApp/Search/Views/PostResultRow.swift
+++ b/iosApp/iosApp/Search/Views/PostResultRow.swift
@@ -13,7 +13,11 @@ struct PostResultRow: View {
                     .fill(Color.gray.opacity(0.3))
                     .frame(width: 40, height: 40)
                     .overlay(
-                        Text(post.authorName?.prefix(1).uppercased() ?? post.authorHandle?.prefix(1).uppercased() ?? "?")
+                        Text({ () -> String in
+                            let nameToUse = post.authorName ?? post.authorHandle ?? ""
+                            guard let firstChar = nameToUse.first else { return "?" }
+                            return String(firstChar).uppercased()
+                        }())
                             .foregroundColor(.gray)
                             .font(.subheadline)
                     )

--- a/iosApp/iosApp/Search/Views/UserResultRow.swift
+++ b/iosApp/iosApp/Search/Views/UserResultRow.swift
@@ -11,11 +11,7 @@ struct UserResultRow: View {
                 .fill(Color.gray.opacity(0.3))
                 .frame(width: 48, height: 48)
                 .overlay(
-                    Text({ () -> String in
-                        let nameToUse = user.displayName ?? user.handle ?? ""
-                        guard let firstChar = nameToUse.first else { return "?" }
-                        return String(firstChar).uppercased()
-                    }())
+                    Text(String((user.displayName ?? user.handle)?.first ?? "?").uppercased())
                         .foregroundColor(.gray)
                         .font(.headline)
                 )

--- a/iosApp/iosApp/Search/Views/UserResultRow.swift
+++ b/iosApp/iosApp/Search/Views/UserResultRow.swift
@@ -11,7 +11,11 @@ struct UserResultRow: View {
                 .fill(Color.gray.opacity(0.3))
                 .frame(width: 48, height: 48)
                 .overlay(
-                    Text(user.displayName?.prefix(1).uppercased() ?? user.handle?.prefix(1).uppercased() ?? "?")
+                    Text({ () -> String in
+                        let nameToUse = user.displayName ?? user.handle ?? ""
+                        guard let firstChar = nameToUse.first else { return "?" }
+                        return String(firstChar).uppercased()
+                    }())
                         .foregroundColor(.gray)
                         .font(.headline)
                 )

--- a/iosApp/iosApp/Views/PostCardView.swift
+++ b/iosApp/iosApp/Views/PostCardView.swift
@@ -16,7 +16,11 @@ struct PostCardView: View {
                     .fill(Color.gray.opacity(0.3))
                     .frame(width: 40, height: 40)
                     .overlay(
-                        Text(String(post.displayName?.prefix(1) ?? post.username?.prefix(1) ?? "?").uppercased())
+                        Text({ () -> String in
+                            let nameToUse = post.displayName ?? post.username ?? ""
+                            guard let firstChar = nameToUse.first else { return "?" }
+                            return String(firstChar).uppercased()
+                        }())
                             .foregroundColor(.gray)
                     )
 

--- a/iosApp/iosApp/Views/PostCardView.swift
+++ b/iosApp/iosApp/Views/PostCardView.swift
@@ -16,11 +16,7 @@ struct PostCardView: View {
                     .fill(Color.gray.opacity(0.3))
                     .frame(width: 40, height: 40)
                     .overlay(
-                        Text({ () -> String in
-                            let nameToUse = post.displayName ?? post.username ?? ""
-                            guard let firstChar = nameToUse.first else { return "?" }
-                            return String(firstChar).uppercased()
-                        }())
+                        Text(String((post.displayName ?? post.username)?.first ?? "?").uppercased())
                             .foregroundColor(.gray)
                     )
 


### PR DESCRIPTION
Fixes two minor UI bugs: updating the copyright year to 2026 across localized string files, and swapping the default "?" avatar fallback character with the user's initial across both the Android Compose and iOS SwiftUI UI layers.

---
*PR created automatically by Jules for task [6750029789344072765](https://jules.google.com/task/6750029789344072765) started by @TheRealAshik*