### PR TITLE
Fix voice message sending flow

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatMediaDelegate.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatMediaDelegate.kt
@@ -27,6 +27,45 @@ class ChatMediaDelegate(
     private val onError: (String?) -> Unit
 ) {
 
+    fun sendMediaMessage(
+        mediaUrl: String,
+        fileName: String,
+        contentType: String,
+        messageType: String,
+        caption: String? = null
+    ) {
+        val chatId = chatIdProvider() ?: return
+        viewModelScope.launch {
+            val tempId = UUID.randomUUID().toString()
+            val type = when (messageType) {
+                "image" -> MessageType.IMAGE
+                "video" -> MessageType.VIDEO
+                "audio" -> MessageType.AUDIO
+                else -> MessageType.FILE
+            }
+            val newMessage = Message(
+                id = tempId,
+                chatId = chatId,
+                senderId = currentUserIdProvider() ?: "",
+                content = "Sending...",
+                messageType = type,
+                deliveryStatus = DeliveryStatus.SENT,
+                createdAt = Instant.now().toString()
+            )
+            onOptimisticMessageAdded(newMessage, tempId)
+            sendMessageUseCase(
+                chatId = chatId,
+                content = if (!caption.isNullOrBlank()) caption else fileName,
+                mediaUrl = mediaUrl,
+                messageType = messageType
+            ).onSuccess { actualMessage ->
+                onOptimisticMessageSuccess(tempId, actualMessage)
+            }.onFailure { e ->
+                onOptimisticMessageFailed(tempId, "Failed to send: ${e.message}")
+            }
+        }
+    }
+
     fun uploadAndSendMedia(
         filePath: String,
         fileName: String,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
@@ -548,6 +548,10 @@ class ChatViewModel @Inject constructor(
         settingsDelegate.setDisappearingMode(mode)
     }
 
+    fun sendMediaMessage(mediaUrl: String, fileName: String, contentType: String, messageType: String, caption: String? = null) {
+        mediaDelegate.sendMediaMessage(mediaUrl, fileName, contentType, messageType, caption)
+    }
+
     fun uploadAndSendMedia(filePath: String, fileName: String, contentType: String, messageType: String, caption: String? = null) {
         mediaDelegate.uploadAndSendMedia(filePath, fileName, contentType, messageType, caption)
     }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
@@ -506,8 +506,8 @@ fun ChatScreen(
                                 coroutineScope.launch {
                                     val result = voiceUploadService.upload(outputFile, com.synapse.social.studioasinc.shared.domain.model.StorageConfig())
                                     result.onSuccess { url ->
-                                        viewModel.uploadAndSendMedia(
-                                            filePath = url,
+                                        viewModel.sendMediaMessage(
+                                            mediaUrl = url,
                                             fileName = "voice_message.m4a",
                                             contentType = "audio/mp4",
                                             messageType = "audio"


### PR DESCRIPTION
Fixes an issue where releasing the microphone button failed to send a recorded voice message. Previously, the flow would attempt to re-upload the remote URL as a local file. The `sendMediaMessage` method was added to bypass the upload step, directly sending the already-uploaded media using `sendMessageUseCase`.

---
*PR created automatically by Jules for task [5720777895379509261](https://jules.google.com/task/5720777895379509261) started by @TheRealAshik*