### PR TITLE
Wire up MediaUploadQuality setting to media compression

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/core/di/StorageModule.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/core/di/StorageModule.kt
@@ -7,7 +7,6 @@ import com.synapse.social.studioasinc.data.local.AppSettingsManager
 import com.synapse.social.studioasinc.data.repository.*
 import com.synapse.social.studioasinc.data.repository.DomainProfileRepositoryAdapter
 import com.synapse.social.studioasinc.data.repository.DomainSettingsRepositoryAdapter
-import com.synapse.social.studioasinc.data.repository.SettingsRepository
 import com.synapse.social.studioasinc.data.repository.SettingsRepositoryImpl
 import com.synapse.social.studioasinc.shared.core.media.AndroidMediaCompressor
 import com.synapse.social.studioasinc.shared.core.network.SupabaseClient
@@ -53,6 +52,7 @@ import com.synapse.social.studioasinc.shared.domain.repository.PasskeyRepository
 import com.synapse.social.studioasinc.shared.domain.repository.PlatformInfoProvider
 import com.synapse.social.studioasinc.shared.domain.repository.PostActionsRepository
 import com.synapse.social.studioasinc.shared.domain.repository.StorageRepository
+import com.synapse.social.studioasinc.shared.domain.repository.SettingsRepository
 import com.synapse.social.studioasinc.shared.domain.repository.UserPreferencesRepository
 import com.synapse.social.studioasinc.shared.domain.service.MediaCompressor
 import com.synapse.social.studioasinc.shared.domain.usecase.CheckForUpdatesUseCase
@@ -172,11 +172,13 @@ object StorageModule {
     @Singleton
     fun provideUploadMediaUseCase(
         repository: StorageRepository,
+        settingsRepository: com.synapse.social.studioasinc.shared.domain.repository.SettingsRepository,
         mediaUploadRepository: MediaUploadRepository,
         mediaCompressor: MediaCompressor
     ): UploadMediaUseCase {
         return UploadMediaUseCase(
             repository,
+            settingsRepository,
             mediaUploadRepository,
             mediaCompressor
         )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/editprofile/EditProfileViewModel.kt
@@ -22,10 +22,17 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import com.synapse.social.studioasinc.data.repository.EditProfileRepositoryImpl
 
+import com.synapse.social.studioasinc.shared.domain.repository.SettingsRepository
+import com.synapse.social.studioasinc.shared.domain.service.MediaCompressor
+import kotlinx.coroutines.flow.first
+
+
 @HiltViewModel
 class EditProfileViewModel @Inject constructor(
     application: Application,
-    private val repository: EditProfileRepositoryImpl
+    private val repository: EditProfileRepositoryImpl,
+    private val settingsRepository: SettingsRepository,
+    private val mediaCompressor: MediaCompressor
 ) : AndroidViewModel(application) {
 
 
@@ -260,22 +267,23 @@ class EditProfileViewModel @Inject constructor(
             return Result.failure(Exception("Source file is empty: $realFilePath"))
         }
 
-        val tempFile = File(context.cacheDir, "temp_avatar_${System.currentTimeMillis()}.jpg")
-        android.util.Log.d("EditProfile", "Compressing image to: ${tempFile.absolutePath}")
+        val quality = settingsRepository.mediaUploadQuality.first()
+        val compressResult = mediaCompressor.compress(realFilePath, quality)
 
-        ImageUtils.resizeBitmapFileRetainRatio(realFilePath, tempFile.absolutePath, 1024)
+        val compressedPath = compressResult.getOrNull() ?: realFilePath
+        val compressedFile = File(compressedPath)
 
-        if (!tempFile.exists() || tempFile.length() == 0L) {
+        if (!compressedFile.exists() || compressedFile.length() == 0L) {
             return Result.failure(Exception("Image compression failed"))
         }
 
-        android.util.Log.d("EditProfile", "Image compressed successfully, size: ${tempFile.length()} bytes")
+        android.util.Log.d("EditProfile", "Image compressed successfully, size: ${compressedFile.length()} bytes")
 
         val userId = repository.getCurrentUserId()
             ?: return Result.failure(Exception("User not logged in"))
 
-        android.util.Log.d("EditProfile", "Starting avatar upload for user: $userId, file: ${tempFile.absolutePath}")
-        return repository.uploadAvatar(userId, tempFile.absolutePath)
+        android.util.Log.d("EditProfile", "Starting avatar upload for user: $userId, file: ${compressedFile.absolutePath}")
+        return repository.uploadAvatar(userId, compressedFile.absolutePath)
     }
 
     @Deprecated("Logic moved to compressAndUploadAvatar and saveProfile")

--- a/shared/src/androidMain/kotlin/com/synapse/social/studioasinc/shared/core/media/AndroidMediaCompressor.kt
+++ b/shared/src/androidMain/kotlin/com/synapse/social/studioasinc/shared/core/media/AndroidMediaCompressor.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.exifinterface.media.ExifInterface
 import com.synapse.social.studioasinc.shared.domain.service.MediaCompressor
+import com.synapse.social.studioasinc.shared.domain.model.settings.MediaUploadQuality
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
@@ -37,12 +38,25 @@ class AndroidMediaCompressor(private val context: Context) : MediaCompressor {
         } else {
             Uri.fromFile(File(filePath))
         }
-        return compress(uri, MAX_FILE_SIZE_BYTES).map { it.absolutePath }
+        return compress(uri, MAX_WIDTH, MAX_HEIGHT, MAX_FILE_SIZE_BYTES, 95).map { it.absolutePath }
     }
 
-    suspend fun compress(uri: Uri, maxSizeBytes: Long): Result<File> = withContext(Dispatchers.IO) {
+    override suspend fun compress(filePath: String, quality: MediaUploadQuality): Result<String> {
+        val uri = if (filePath.startsWith("content://")) {
+            Uri.parse(filePath)
+        } else {
+            Uri.fromFile(File(filePath))
+        }
+        val maxWidth = if (quality == MediaUploadQuality.HD) 1920 else 1280
+        val maxHeight = if (quality == MediaUploadQuality.HD) 1920 else 1280
+        val maxSizeBytes = if (quality == MediaUploadQuality.HD) 3 * 1024 * 1024L else 1 * 1024 * 1024L
+        val maxQuality = if (quality == MediaUploadQuality.HD) 95 else 80
+        return compress(uri, maxWidth, maxHeight, maxSizeBytes, maxQuality).map { it.absolutePath }
+    }
+
+    suspend fun compress(uri: Uri, maxWidth: Int, maxHeight: Int, maxSizeBytes: Long, maxQuality: Int): Result<File> = withContext(Dispatchers.IO) {
         try {
-            val decodedBitmap = decodeImage(uri, MAX_WIDTH, MAX_HEIGHT)
+            val decodedBitmap = decodeImage(uri, maxWidth, maxHeight)
                 ?: return@withContext Result.failure(IOException("Failed to decode bitmap from $uri"))
 
             val orientedBitmap = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
@@ -55,7 +69,7 @@ class AndroidMediaCompressor(private val context: Context) : MediaCompressor {
                 decodedBitmap
             }
 
-            val scaledBitmap = scaleToTargetSize(orientedBitmap, MAX_WIDTH, MAX_HEIGHT)
+            val scaledBitmap = scaleToTargetSize(orientedBitmap, maxWidth, maxHeight)
 
             if (scaledBitmap != orientedBitmap && scaledBitmap != decodedBitmap) {
                 orientedBitmap.recycle()
@@ -69,7 +83,7 @@ class AndroidMediaCompressor(private val context: Context) : MediaCompressor {
                 return@withContext Result.failure(IOException("Bitmap too large to process safely"))
             }
 
-            val compressedFile = compressIteratively(scaledBitmap, maxSizeBytes)
+            val compressedFile = compressIteratively(scaledBitmap, maxSizeBytes, maxQuality)
 
             scaledBitmap.recycle()
 
@@ -284,11 +298,11 @@ class AndroidMediaCompressor(private val context: Context) : MediaCompressor {
         }
     }
 
-    private suspend fun compressIteratively(bitmap: Bitmap, targetSizeBytes: Long): File = withContext(Dispatchers.IO) {
+    private suspend fun compressIteratively(bitmap: Bitmap, targetSizeBytes: Long, initialMaxQuality: Int): File = withContext(Dispatchers.IO) {
         val tempFile = File.createTempFile("compressed_image_", ".jpg", context.cacheDir)
 
         var minQuality = MIN_COMPRESSION_QUALITY
-        var maxQuality = 95
+        var maxQuality = initialMaxQuality
         var bestQuality = minQuality
         var bestData: ByteArray? = null
 

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/di/StorageModule.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/di/StorageModule.kt
@@ -125,6 +125,6 @@ val storageModule = module {
     single { ValidateProviderConfigUseCase() }
 
     single<MediaUploadRepository> { MediaUploadRepositoryImpl(get(), get(), get(), get(), get()) }
-    single { UploadMediaUseCase(get(), get(), get()) }
+    single { UploadMediaUseCase(get(), get(), get(), get()) }
 
 }

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/service/MediaCompressor.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/service/MediaCompressor.kt
@@ -1,5 +1,8 @@
 package com.synapse.social.studioasinc.shared.domain.service
 
+import com.synapse.social.studioasinc.shared.domain.model.settings.MediaUploadQuality
+
 interface MediaCompressor {
     suspend fun compress(filePath: String): Result<String>
+    suspend fun compress(filePath: String, quality: MediaUploadQuality): Result<String>
 }

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/UploadMediaUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/UploadMediaUseCase.kt
@@ -5,11 +5,13 @@ import com.synapse.social.studioasinc.shared.domain.model.StorageConfig
 import com.synapse.social.studioasinc.shared.domain.model.StorageProvider
 import com.synapse.social.studioasinc.shared.domain.repository.MediaUploadRepository
 import com.synapse.social.studioasinc.shared.domain.repository.StorageRepository
+import com.synapse.social.studioasinc.shared.domain.repository.SettingsRepository
 import com.synapse.social.studioasinc.shared.domain.service.MediaCompressor
 import kotlinx.coroutines.flow.first
 
 class UploadMediaUseCase(
     private val repository: StorageRepository,
+    private val settingsRepository: SettingsRepository,
     private val mediaUploadRepository: MediaUploadRepository,
     private val mediaCompressor: MediaCompressor
 ) {
@@ -26,7 +28,7 @@ class UploadMediaUseCase(
             var shouldDelete = false
 
             if ((mediaType == MediaType.PHOTO || mediaType == MediaType.IMAGE) && config.compressImages) {
-                mediaCompressor.compress(filePath).onSuccess { compressedPath ->
+                mediaCompressor.compress(filePath, settingsRepository.mediaUploadQuality.first()).onSuccess { compressedPath ->
                     if (compressedPath != filePath) {
                         uploadPath = compressedPath
                         shouldDelete = true

--- a/shared/src/iosMain/kotlin/com/synapse/social/studioasinc/shared/core/media/IosMediaCompressor.kt
+++ b/shared/src/iosMain/kotlin/com/synapse/social/studioasinc/shared/core/media/IosMediaCompressor.kt
@@ -1,6 +1,8 @@
 package com.synapse.social.studioasinc.shared.core.media
 
 import com.synapse.social.studioasinc.shared.domain.service.MediaCompressor
+import com.synapse.social.studioasinc.shared.domain.model.settings.MediaUploadQuality
+
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSTemporaryDirectory
@@ -44,5 +46,9 @@ class IosMediaCompressor : MediaCompressor {
         } catch (e: Exception) {
             Result.failure(e)
         }
+    }
+
+    override suspend fun compress(filePath: String, quality: MediaUploadQuality): Result<String> {
+        return compress(filePath)
     }
 }

--- a/shared/src/jvmMain/kotlin/com/synapse/social/studioasinc/shared/core/media/JvmMediaCompressor.kt
+++ b/shared/src/jvmMain/kotlin/com/synapse/social/studioasinc/shared/core/media/JvmMediaCompressor.kt
@@ -1,7 +1,13 @@
 package com.synapse.social.studioasinc.shared.core.media
 
 import com.synapse.social.studioasinc.shared.domain.service.MediaCompressor
+import com.synapse.social.studioasinc.shared.domain.model.settings.MediaUploadQuality
+
 
 class JvmMediaCompressor : MediaCompressor {
     override suspend fun compress(filePath: String): Result<String> = Result.success(filePath)
+
+    override suspend fun compress(filePath: String, quality: MediaUploadQuality): Result<String> {
+        return compress(filePath)
+    }
 }

--- a/shared/src/wasmJsMain/kotlin/com/synapse/social/studioasinc/shared/core/media/WasmJsMediaCompressor.kt
+++ b/shared/src/wasmJsMain/kotlin/com/synapse/social/studioasinc/shared/core/media/WasmJsMediaCompressor.kt
@@ -1,7 +1,13 @@
 package com.synapse.social.studioasinc.shared.core.media
 
 import com.synapse.social.studioasinc.shared.domain.service.MediaCompressor
+import com.synapse.social.studioasinc.shared.domain.model.settings.MediaUploadQuality
+
 
 class WasmJsMediaCompressor : MediaCompressor {
     override suspend fun compress(filePath: String): Result<String> = Result.success(filePath)
+
+    override suspend fun compress(filePath: String, quality: MediaUploadQuality): Result<String> {
+        return compress(filePath)
+    }
 }


### PR DESCRIPTION
- Extended `MediaCompressor` interface to accept `MediaUploadQuality`.
- Updated `AndroidMediaCompressor` to support scaling down by max dimension, filesize, and JPEG quality limit.
- Wired `SettingsRepository` into `UploadMediaUseCase` and `EditProfileViewModel` (for avatar uploads).
- Updated DI configurations.

---
*PR created automatically by Jules for task [9620661330726717833](https://jules.google.com/task/9620661330726717833) started by @TheRealAshik*