### PR TITLE
Implement Share to Story and Share via Message

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
@@ -324,7 +324,10 @@ class ChatViewModel @Inject constructor(
     val messageSummary: StateFlow<String?> = aiDelegate.messageSummary
     val isSummarizingMessage: StateFlow<Boolean> = aiDelegate.isSummarizingMessage
 
-    fun initialize(chatId: String, participantId: String? = null) {
+    fun initialize(chatId: String, participantId: String? = null, prefilledText: String? = null) {
+        if (!prefilledText.isNullOrEmpty() && _inputText.value.isEmpty()) {
+            _inputText.value = prefilledText
+        }
         if (currentChatId == chatId && chatId != "new") return
         
         cleanup()

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/InboxScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/InboxScreen.kt
@@ -29,8 +29,9 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InboxScreen(
+    shareText: String? = null,
     onNavigateToProfile: (String) -> Unit,
-    onNavigateToChat: (String, String?, String?, String?) -> Unit,
+    onNavigateToChat: (String, String?, String?, String?, String?) -> Unit,
     onNavigateToSearch: () -> Unit,
     onNavigateToCreateGroup: () -> Unit = {},
     viewModel: InboxViewModel = hiltViewModel()
@@ -144,12 +145,12 @@ fun InboxScreen(
                                     if (activity != null) {
                                         viewModel.authenticateChat(
                                             activity = activity,
-                                            onSuccess = { onNavigateToChat(chatId, userId, userName, avatar) },
+                                            onSuccess = { onNavigateToChat(chatId, userId, userName, avatar, shareText) },
                                             onError = { /* Handle error, maybe show Snackbar */ }
                                         )
                                     }
                                 } else {
-                                    onNavigateToChat(chatId, userId, userName, avatar)
+                                    onNavigateToChat(chatId, userId, userName, avatar, shareText)
                                 }
                             },
                             isLocked = { viewModel.isChatLocked(it) },
@@ -170,6 +171,7 @@ fun InboxScreen(
                     contentPadding = paddingValues
                 )
                 2 -> ContactsTabScreen(
+                    shareText = shareText,
                     onNavigateToChat = onNavigateToChat,
                     onNavigateToSearch = onNavigateToSearch,
                     contentPadding = paddingValues

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
@@ -160,6 +160,7 @@ fun ChatScreen(
     participantId: String? = null,
     initialParticipantName: String? = null,
     initialParticipantAvatar: String? = null,
+    prefilledText: String? = null,
     onNavigateBack: () -> Unit,
     onNavigateToGroupInfo: (String, String) -> Unit = { _, _ -> },
     onNavigateToUserMoreOptions: (String) -> Unit = {},
@@ -168,7 +169,7 @@ fun ChatScreen(
 ) {
     // Initialize the ViewModel with the chat ID
     LaunchedEffect(chatId) {
-        viewModel.initialize(chatId, participantId)
+        viewModel.initialize(chatId, participantId, prefilledText)
     }
 
     // Re-fetch messages when screen resumes (catches messages missed while screen was off)
@@ -393,7 +394,7 @@ fun ChatScreen(
                             color = MaterialTheme.colorScheme.error
                         )
                         Spacer(modifier = Modifier.height(Spacing.Small))
-                        TextButton(onClick = { viewModel.initialize(chatId, participantId) }) {
+                        TextButton(onClick = { viewModel.initialize(chatId, participantId, prefilledText) }) {
                             Text(stringResource(R.string.action_retry))
                         }
                     }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ContactsTabScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ContactsTabScreen.kt
@@ -36,7 +36,8 @@ import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ContactsTabScreen(
-    onNavigateToChat: (String, String?, String?, String?) -> Unit,
+    shareText: String? = null,
+    onNavigateToChat: (String, String?, String?, String?, String?) -> Unit,
     onNavigateToSearch: () -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
@@ -94,7 +95,7 @@ fun ContactsTabScreen(
                             ContactItem(
                                 contact = contact,
                                 onContactClick = { user ->
-                                    onNavigateToChat(user.uid, user.uid, user.displayName ?: user.username, user.avatar)
+                                    onNavigateToChat(user.uid, user.uid, user.displayName ?: user.username, user.avatar, shareText)
                                 },
                                 onContactLongClick = { user ->
                                     // Placeholder for options

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileContentSection.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileContentSection.kt
@@ -49,7 +49,7 @@ internal fun ProfileContent(
     onNavigateToQuotePost: (String) -> Unit,
     onNavigateToUserProfile: (String) -> Unit,
     onNavigateToChat: (String, String?, String?) -> Unit,
-    onNavigateToStoryCreator: () -> Unit,
+    onNavigateToStoryCreator: (String?) -> Unit,
     onCustomizeClick: () -> Unit = {},
     onOpenMediaViewer: (List<String>, Int) -> Unit,
     onShowPostOptions: (Post) -> Unit
@@ -163,7 +163,7 @@ internal fun ProfileContent(
                         }
                     },
                     onMessageClick = { onNavigateToChat(profile.id, profile.name ?: profile.username, profile.avatar) },
-                    onAddStoryClick = onNavigateToStoryCreator,
+                    onAddStoryClick = { onNavigateToStoryCreator(null) },
                     onMoreClick = { viewModel.toggleMoreMenu() },
                     onStatsClick = { stat ->
                         when (stat) {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileDialogs.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileDialogs.kt
@@ -50,7 +50,9 @@ internal fun ShareProfileSection(
     viewModel: ProfileViewModel,
     profile: com.synapse.social.studioasinc.data.model.UserProfile?,
     context: Context,
-    profileLinkLabel: String
+    profileLinkLabel: String,
+    onNavigateToStoryCreator: (String?) -> Unit,
+    onNavigateToInbox: (String?) -> Unit
 ) {
     if (state.showShareSheet) {
         ShareProfileBottomSheet(
@@ -65,11 +67,15 @@ internal fun ShareProfileSection(
                 viewModel.hideShareSheet()
             },
             onShareToStory = {
-                Toast.makeText(context, context.getString(R.string.toast_share_story_soon), Toast.LENGTH_SHORT).show()
+                val username = profile?.username ?: ""
+                val url = "${BuildConfig.APP_DOMAIN}/profile/$username"
+                onNavigateToStoryCreator(url)
                 viewModel.hideShareSheet()
             },
             onShareViaMessage = {
-                Toast.makeText(context, context.getString(R.string.toast_share_message_soon), Toast.LENGTH_SHORT).show()
+                val username = profile?.username ?: ""
+                val url = "${BuildConfig.APP_DOMAIN}/profile/$username"
+                onNavigateToInbox(url)
                 viewModel.hideShareSheet()
             },
             onShareExternal = {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileScreen.kt
@@ -63,7 +63,8 @@ fun ProfileScreen(
     onNavigateToSettings: () -> Unit = {},
     onNavigateToUserProfile: (String) -> Unit = {},
     onNavigateToChat: (String, String?, String?) -> Unit = { _, _, _ -> },
-    onNavigateToStoryCreator: () -> Unit = {},
+    onNavigateToStoryCreator: (String?) -> Unit = {},
+    onNavigateToInbox: (String?) -> Unit = {},
     onNavigateToQuotePost: (String) -> Unit = {},
     viewModel: ProfileViewModel = hiltViewModel()
 ) {
@@ -211,7 +212,9 @@ fun ProfileScreen(
             viewModel = viewModel,
             profile = profile,
             context = context,
-            profileLinkLabel = profileLinkLabel
+            profileLinkLabel = profileLinkLabel,
+            onNavigateToStoryCreator = onNavigateToStoryCreator,
+            onNavigateToInbox = onNavigateToInbox
         )
 
         ViewAsSection(

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/navigation/AppDestination.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/navigation/AppDestination.kt
@@ -8,7 +8,7 @@ sealed interface AppDestination {
     @Serializable
     data class Profile(val userId: String) : AppDestination
     @Serializable
-    data object Inbox : AppDestination
+    data class Inbox(val shareText: String? = null) : AppDestination
     @Serializable
     data object Search : AppDestination
     @Serializable
@@ -32,12 +32,13 @@ sealed interface AppDestination {
         val chatId: String, 
         val userId: String? = null,
         val participantName: String? = null,
-        val participantAvatar: String? = null
+        val participantAvatar: String? = null,
+        val prefilledText: String? = null
     ) : AppDestination
     @Serializable
     data class StoryViewer(val userId: String) : AppDestination
     @Serializable
-    data object StoryCreator : AppDestination
+    data class StoryCreator(val shareUrl: String? = null) : AppDestination
     @Serializable
     data object ChatPrivacy : AppDestination
     @Serializable

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/navigation/AppNavigation.kt
@@ -131,13 +131,15 @@ fun NavGraphBuilder.homeGraph(navController: NavHostController, reelUploadManage
 }
 
 fun NavGraphBuilder.inboxGraph(navController: NavHostController) {
-    composable<AppDestination.Inbox> {
+    composable<AppDestination.Inbox> { backStackEntry ->
+                val args = backStackEntry.toRoute<AppDestination.Inbox>()
                 InboxScreen(
+                    shareText = args.shareText,
                     onNavigateToProfile = { userId ->
                         navController.navigate(AppDestination.Profile(userId))
                     },
-                    onNavigateToChat = { chatId, userId, userName, avatar ->
-                        navController.navigate(AppDestination.Chat(chatId, userId, userName, avatar))
+                    onNavigateToChat = { chatId, userId, userName, avatar, prefilledText ->
+                        navController.navigate(AppDestination.Chat(chatId, userId, userName, avatar, prefilledText))
                     },
                     onNavigateToSearch = {
                         navController.navigate(AppDestination.Search)
@@ -152,6 +154,7 @@ fun NavGraphBuilder.inboxGraph(navController: NavHostController) {
                     participantId = args.userId,
                     initialParticipantName = args.participantName,
                     initialParticipantAvatar = args.participantAvatar,
+                    prefilledText = args.prefilledText,
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToGroupInfo = { chatId, groupName ->
                         navController.navigate(AppDestination.GroupInfo(chatId, groupName))
@@ -228,8 +231,13 @@ fun NavGraphBuilder.profileGraph(navController: NavHostController) {
                     onNavigateToUserProfile = { targetUid ->
                         navController.navigate(AppDestination.Profile(targetUid))
                     },
-                    onNavigateToStoryCreator = {
-                        context.startActivity(Intent(context, StoryCreatorActivity::class.java))
+                    onNavigateToStoryCreator = { shareUrl ->
+                        val intent = Intent(context, StoryCreatorActivity::class.java)
+                        shareUrl?.let { intent.putExtra(com.synapse.social.studioasinc.feature.stories.creator.EXTRA_SHARE_URL, it) }
+                        context.startActivity(intent)
+                    },
+                    onNavigateToInbox = { shareText ->
+                        navController.navigate(AppDestination.Inbox(shareText))
                     },
                     viewModel = viewModel
                 )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/creator/StoryCreatorScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/creator/StoryCreatorScreen.kt
@@ -71,18 +71,21 @@ import androidx.media3.ui.PlayerView
 import androidx.media3.ui.AspectRatioFrameLayout
 
 const val EXTRA_SHARED_POST_ID = "shared_post_id"
+const val EXTRA_SHARE_URL = "share_url"
 
 @AndroidEntryPoint
 class StoryCreatorActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val sharedPostId = intent.getStringExtra(EXTRA_SHARED_POST_ID)
+        val shareUrl = intent.getStringExtra(EXTRA_SHARE_URL)
         setContent {
             SynapseTheme {
                 StoryCreatorScreen(
                     onClose = { finish() },
                     onStoryPosted = { finish() },
-                    sharedPostId = sharedPostId
+                    sharedPostId = sharedPostId,
+                    shareUrl = shareUrl
                 )
             }
         }
@@ -128,6 +131,7 @@ fun StoryCreatorScreen(
     onClose: () -> Unit,
     onStoryPosted: () -> Unit,
     sharedPostId: String? = null,
+    shareUrl: String? = null,
     viewModel: StoryCreatorViewModel = hiltViewModel(),
     modifier: Modifier = Modifier
 ) {
@@ -137,6 +141,12 @@ fun StoryCreatorScreen(
     LaunchedEffect(sharedPostId) {
         if (sharedPostId != null) {
             viewModel.loadSharedPost(sharedPostId)
+        }
+    }
+
+    LaunchedEffect(shareUrl) {
+        if (shareUrl != null) {
+            viewModel.addTextOverlay(shareUrl)
         }
     }
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/creator/StoryCreatorViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/stories/creator/StoryCreatorViewModel.kt
@@ -205,11 +205,11 @@ class StoryCreatorViewModel @Inject constructor(
         }
     }
 
-    fun addTextOverlay() {
+    fun addTextOverlay(initialText: String = "") {
         _state.update { state ->
             state.copy(
                 textOverlays = state.textOverlays + TextOverlay(
-                    text = "",
+                    text = initialText,
                     position = Offset(100f, 100f)
                 )
             )


### PR DESCRIPTION
Implements the two currently mocked "Share Profile" options end-to-end: Share to Story, and Share via Message. Navigates to StoryCreator with a text overlay prefilled, and to Chat via Inbox with a message draft prefilled.

---
*PR created automatically by Jules for task [17518816088625389279](https://jules.google.com/task/17518816088625389279) started by @TheRealAshik*