### PR TITLE
Add AnimatedCounter to follow/unfollow counts in ProfileHeader

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/components/ProfileHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/components/ProfileHeader.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.res.stringResource
 import com.synapse.social.studioasinc.R
 import androidx.compose.ui.unit.dp
+import com.synapse.social.studioasinc.feature.shared.components.AnimatedCounter
 import com.synapse.social.studioasinc.feature.shared.components.ButtonVariant
 import com.synapse.social.studioasinc.feature.shared.components.ExpressiveButton
 import com.synapse.social.studioasinc.feature.shared.components.animatedShape
@@ -436,8 +437,6 @@ private fun InlineStatsText(
     onStatsClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val formattedFollowers = com.synapse.social.studioasinc.core.util.NumberFormatter.formatCount(followersCount)
-    val formattedFollowing = com.synapse.social.studioasinc.core.util.NumberFormatter.formatCount(followingCount)
     val formattedPosts = com.synapse.social.studioasinc.core.util.NumberFormatter.formatCount(postsCount)
 
     FlowRow(
@@ -449,12 +448,14 @@ private fun InlineStatsText(
             modifier = Modifier.clickable { onStatsClick("followers") },
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = formattedFollowers,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
-            )
+            AnimatedCounter(count = followersCount) { count ->
+                Text(
+                    text = com.synapse.social.studioasinc.core.util.NumberFormatter.formatCount(count),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
             Spacer(modifier = Modifier.width(Spacing.ExtraSmall))
             Text(
                 text = stringResource(R.string.followers).lowercase(),
@@ -474,12 +475,14 @@ private fun InlineStatsText(
             modifier = Modifier.clickable { onStatsClick("following") },
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = formattedFollowing,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
-            )
+            AnimatedCounter(count = followingCount) { count ->
+                Text(
+                    text = com.synapse.social.studioasinc.core.util.NumberFormatter.formatCount(count),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
             Spacer(modifier = Modifier.width(Spacing.ExtraSmall))
             Text(
                 text = stringResource(R.string.following).lowercase(),

--- a/iosApp/iosApp/Core/Components/AnimatedCounter.swift
+++ b/iosApp/iosApp/Core/Components/AnimatedCounter.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct AnimatedCounter: View {
+    let count: Int
+    let font: Font
+    let fontWeight: Font.Weight
+    let color: Color
+
+    init(
+        count: Int,
+        font: Font = .body,
+        fontWeight: Font.Weight = .regular,
+        color: Color = .primary
+    ) {
+        self.count = count
+        self.font = font
+        self.fontWeight = fontWeight
+        self.color = color
+    }
+
+    var body: some View {
+        Text(formatCount(count))
+            .font(font)
+            .fontWeight(fontWeight)
+            .foregroundColor(color)
+            .contentTransition(.numericText())
+            .animation(.spring(response: 0.35, dampingFraction: 0.7), value: count)
+    }
+
+    private func formatCount(_ count: Int) -> String {
+        if count >= 1_000_000_000 {
+            let formatted = Double(count) / 1_000_000_000.0
+            return formatted.truncatingRemainder(dividingBy: 1) == 0
+                ? String(format: "%.0fB", formatted)
+                : String(format: "%.1fB", formatted)
+        } else if count >= 1_000_000 {
+            let formatted = Double(count) / 1_000_000.0
+            return formatted.truncatingRemainder(dividingBy: 1) == 0
+                ? String(format: "%.0fM", formatted)
+                : String(format: "%.1fM", formatted)
+        } else if count >= 1_000 {
+            let formatted = Double(count) / 1_000.0
+            return String(format: "%.1fK", formatted)
+        } else {
+            return "\(count)"
+        }
+    }
+}

--- a/iosApp/iosApp/Profile/ProfileView.swift
+++ b/iosApp/iosApp/Profile/ProfileView.swift
@@ -27,7 +27,11 @@ struct ProfileView: View {
                     HStack(spacing: 40) {
                         NavigationLink(destination: FollowersFollowingView()) {
                             VStack {
-                                Text("\(viewModel.user?.followersCount ?? 0)").font(.headline)
+                                AnimatedCounter(
+                                    count: Int(viewModel.user?.followersCount ?? 0),
+                                    font: .headline,
+                                    fontWeight: .bold
+                                )
                                 Text("Followers").font(.caption)
                             }
                         }
@@ -36,7 +40,11 @@ struct ProfileView: View {
 
                         NavigationLink(destination: FollowersFollowingView()) {
                             VStack {
-                                Text("\(viewModel.user?.followingCount ?? 0)").font(.headline)
+                                AnimatedCounter(
+                                    count: Int(viewModel.user?.followingCount ?? 0),
+                                    font: .headline,
+                                    fontWeight: .bold
+                                )
                                 Text("Following").font(.caption)
                             }
                         }


### PR DESCRIPTION
This PR adds animations to the follower and following counts in the ProfileHeader component for both Android and iOS. 

On Android, the existing `AnimatedCounter` component is utilized. On iOS, a new `AnimatedCounter` component was implemented using SwiftUI's native numeric text transitions to achieve a similar effect.

Changes:
- **Android**: `app/src/main/kotlin/.../profile/components/ProfileHeader.kt` updated to use `AnimatedCounter`.
- **iOS**: Created `iosApp/iosApp/Core/Components/AnimatedCounter.swift`.
- **iOS**: Updated `iosApp/iosApp/Profile/ProfileView.swift` to use `AnimatedCounter`.

Fixes #129

---
*PR created automatically by Jules for task [6635964320765049679](https://jules.google.com/task/6635964320765049679) started by @TheRealAshik*