### PR TITLE
Skeleton-to-Content Morphing Transition

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/core/ui/animation/SkeletonMorphing.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/core/ui/animation/SkeletonMorphing.kt
@@ -1,0 +1,40 @@
+package com.synapse.social.studioasinc.core.ui.animation
+
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * A component that handles a smooth transition from a skeleton/shimmer state to the actual content.
+ * It performs a cross-fade and subtle scale effect to avoid jarring "pop-ins".
+ */
+@Composable
+fun SkeletonMorphedContent(
+    isLoading: Boolean,
+    modifier: Modifier = Modifier,
+    skeleton: @Composable () -> Unit,
+    content: @Composable () -> Unit
+) {
+    AnimatedContent(
+        targetState = isLoading,
+        transitionSpec = {
+            if (initialState && !targetState) {
+                // Transitioning from Loading (Skeleton) to Content
+                (fadeIn(animationSpec = tween(400)) + scaleIn(initialScale = 0.95f, animationSpec = tween(400)))
+                    .togetherWith(fadeOut(animationSpec = tween(400)) + scaleOut(targetScale = 1.05f, animationSpec = tween(400)))
+            } else {
+                // Default transition for other state changes
+                fadeIn(animationSpec = tween(400)) togetherWith fadeOut(animationSpec = tween(400))
+            }
+        },
+        label = "SkeletonMorphing",
+        modifier = modifier
+    ) { loading ->
+        if (loading) {
+            skeleton()
+        } else {
+            content()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileContentSection.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileContentSection.kt
@@ -29,6 +29,7 @@ import com.synapse.social.studioasinc.feature.shared.components.post.PostActions
 import com.synapse.social.studioasinc.feature.shared.components.post.PostActionsFactory
 import com.synapse.social.studioasinc.feature.shared.components.post.PostCard
 import com.synapse.social.studioasinc.feature.shared.components.post.SharedPostItem
+import com.synapse.social.studioasinc.core.ui.animation.SkeletonMorphedContent
 import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 import com.synapse.social.studioasinc.ui.components.EmptyState
 import kotlinx.coroutines.delay
@@ -120,128 +121,144 @@ internal fun ProfileContent(
         }
 
         item {
-            if (profile != null) {
-                ProfileHeader(
-                    avatar = profile.avatar,
-                    status = profile.status,
-                    coverImageUrl = profile.coverImageUrl,
-                    name = profile.name,
-                    username = profile.username,
-                    nickname = profile.nickname,
-                    bio = profile.bio,
-                    isVerified = profile.isVerified,
-                    hasStory = state.hasStory,
-                    postsCount = profile.postCount,
-                    followersCount = profile.followerCount,
-                    followingCount = profile.followingCount,
-                    isOwnProfile = state.isOwnProfile && state.viewAsMode == null,
-                    isFollowing = state.isFollowing,
-                    isFollowLoading = state.isFollowLoading,
-                    scrollOffset = scrollProgress,
-                    bioExpanded = bioExpanded,
-                    onToggleBio = { bioExpanded = !bioExpanded },
-                    onProfileImageClick = {
-                         if (state.isOwnProfile) {
-                             onNavigateToEditProfile()
-                         } else if (!profile.avatar.isNullOrBlank()) {
-                             onOpenMediaViewer(listOf(profile.avatar), 0)
-                         }
-                    },
-                    onCoverPhotoClick = {
-                         if (state.isOwnProfile) {
-                             onNavigateToEditProfile()
-                         } else if (!profile.coverImageUrl.isNullOrBlank()) {
-                             onOpenMediaViewer(listOf(profile.coverImageUrl), 0)
-                         }
-                    },
-                    onEditProfileClick = onNavigateToEditProfile,
-                    onFollowClick = {
-                        if (state.isFollowing) {
-                            viewModel.unfollowUser(profile.id)
-                        } else {
-                            viewModel.followUser(profile.id)
-                        }
-                    },
-                    onMessageClick = { onNavigateToChat(profile.id, profile.name ?: profile.username, profile.avatar) },
-                    onAddStoryClick = onNavigateToStoryCreator,
-                    onMoreClick = { viewModel.toggleMoreMenu() },
-                    onStatsClick = { stat ->
-                        when (stat) {
-                            "followers" -> onNavigateToFollowers()
-                            "following" -> onNavigateToFollowing()
-                        }
+            SkeletonMorphedContent(
+                isLoading = isLoading && profile == null,
+                skeleton = {
+                    Column {
+                        ProfileHeaderShimmer()
+                        ProfileBioShimmer(displayName = state.viewAsUserName)
+                        Spacer(modifier = Modifier.height(Spacing.Medium))
+                        ProfileStatsShimmer()
+                        Spacer(modifier = Modifier.height(Spacing.Medium))
+                        ProfileActionsShimmer()
+                        Spacer(modifier = Modifier.height(Spacing.Medium))
                     }
-                )
-            } else if (isLoading) {
-                Column {
-                    ProfileHeaderShimmer()
-                    ProfileBioShimmer(displayName = state.viewAsUserName)
-                    Spacer(modifier = Modifier.height(Spacing.Medium))
-                    ProfileStatsShimmer()
-                    Spacer(modifier = Modifier.height(Spacing.Medium))
-                    ProfileActionsShimmer()
-                    Spacer(modifier = Modifier.height(Spacing.Medium))
+                }
+            ) {
+                if (profile != null) {
+                    ProfileHeader(
+                        avatar = profile.avatar,
+                        status = profile.status,
+                        coverImageUrl = profile.coverImageUrl,
+                        name = profile.name,
+                        username = profile.username,
+                        nickname = profile.nickname,
+                        bio = profile.bio,
+                        isVerified = profile.isVerified,
+                        hasStory = state.hasStory,
+                        postsCount = profile.postCount,
+                        followersCount = profile.followerCount,
+                        followingCount = profile.followingCount,
+                        isOwnProfile = state.isOwnProfile && state.viewAsMode == null,
+                        isFollowing = state.isFollowing,
+                        isFollowLoading = state.isFollowLoading,
+                        scrollOffset = scrollProgress,
+                        bioExpanded = bioExpanded,
+                        onToggleBio = { bioExpanded = !bioExpanded },
+                        onProfileImageClick = {
+                            if (state.isOwnProfile) {
+                                onNavigateToEditProfile()
+                            } else if (!profile.avatar.isNullOrBlank()) {
+                                onOpenMediaViewer(listOf(profile.avatar), 0)
+                            }
+                        },
+                        onCoverPhotoClick = {
+                            if (state.isOwnProfile) {
+                                onNavigateToEditProfile()
+                            } else if (!profile.coverImageUrl.isNullOrBlank()) {
+                                onOpenMediaViewer(listOf(profile.coverImageUrl), 0)
+                            }
+                        },
+                        onEditProfileClick = onNavigateToEditProfile,
+                        onFollowClick = {
+                            if (state.isFollowing) {
+                                viewModel.unfollowUser(profile.id)
+                            } else {
+                                viewModel.followUser(profile.id)
+                            }
+                        },
+                        onMessageClick = {
+                            onNavigateToChat(
+                                profile.id,
+                                profile.name ?: profile.username,
+                                profile.avatar
+                            )
+                        },
+                        onAddStoryClick = onNavigateToStoryCreator,
+                        onMoreClick = { viewModel.toggleMoreMenu() },
+                        onStatsClick = { stat ->
+                            when (stat) {
+                                "followers" -> onNavigateToFollowers()
+                                "following" -> onNavigateToFollowing()
+                            }
+                        }
+                    )
                 }
             }
         }
 
         item {
-            if (profile != null) {
-                Column {
-                    Spacer(modifier = Modifier.height(Spacing.Medium))
-                    UserDetailsSection(
-                        details = UserDetails(
-                            location = profile.location,
-                            joinedDate = formatJoinedDate(profile.joinedDate),
-                            relationshipStatus = profile.relationshipStatus,
-                            birthday = profile.birthday,
-                            work = profile.work,
-                            education = profile.education,
-                            website = profile.website,
-                            gender = profile.gender,
-                            pronouns = profile.pronouns,
-                            linkedAccounts = profile.linkedAccounts.map {
-                                LinkedAccount(
-                                    platform = it.platform,
-                                    username = it.username
-                                )
-                            },
-                            currentCity = profile.currentCity,
-                            hometown = profile.hometown,
-                            occupation = profile.occupation,
-                            workplace = profile.workplace,
-                            discordTag = profile.discordTag,
-                            githubProfile = profile.githubProfile,
-                            personalWebsite = profile.personalWebsite,
-                            publicEmail = profile.publicEmail
-                        ),
-                        isOwnProfile = state.isOwnProfile,
-                        onCustomizeClick = onCustomizeClick,
-                        onWebsiteClick = { url ->
-                             IntentUtils.openUrl(context, url)
-                         },
-                        modifier = Modifier.padding(horizontal = Spacing.Medium)
-                    )
-
-                    Spacer(modifier = Modifier.height(Spacing.Medium))
-
-                    FollowingSection(
-                        users = state.followingList,
-                        selectedFilter = FollowingFilter.ALL,
-                        onFilterSelected = { },
-                        onUserClick = { user -> onNavigateToUserProfile(user.id) },
-                        onSeeAllClick = onNavigateToFollowing,
-                        modifier = Modifier.padding(horizontal = Spacing.Medium)
-                    )
-
-                    Spacer(modifier = Modifier.height(Spacing.Medium))
+            SkeletonMorphedContent(
+                isLoading = isLoading && profile == null,
+                skeleton = {
+                    Column {
+                        ProfileDetailsShimmer()
+                        Spacer(modifier = Modifier.height(Spacing.Medium))
+                        FollowingSectionShimmer()
+                        Spacer(modifier = Modifier.height(Spacing.Medium))
+                    }
                 }
-            } else if (isLoading) {
-                Column {
-                    ProfileDetailsShimmer()
-                    Spacer(modifier = Modifier.height(Spacing.Medium))
-                    FollowingSectionShimmer()
-                    Spacer(modifier = Modifier.height(Spacing.Medium))
+            ) {
+                if (profile != null) {
+                    Column {
+                        Spacer(modifier = Modifier.height(Spacing.Medium))
+                        UserDetailsSection(
+                            details = UserDetails(
+                                location = profile.location,
+                                joinedDate = formatJoinedDate(profile.joinedDate),
+                                relationshipStatus = profile.relationshipStatus,
+                                birthday = profile.birthday,
+                                work = profile.work,
+                                education = profile.education,
+                                website = profile.website,
+                                gender = profile.gender,
+                                pronouns = profile.pronouns,
+                                linkedAccounts = profile.linkedAccounts.map {
+                                    LinkedAccount(
+                                        platform = it.platform,
+                                        username = it.username
+                                    )
+                                },
+                                currentCity = profile.currentCity,
+                                hometown = profile.hometown,
+                                occupation = profile.occupation,
+                                workplace = profile.workplace,
+                                discordTag = profile.discordTag,
+                                githubProfile = profile.githubProfile,
+                                personalWebsite = profile.personalWebsite,
+                                publicEmail = profile.publicEmail
+                            ),
+                            isOwnProfile = state.isOwnProfile,
+                            onCustomizeClick = onCustomizeClick,
+                            onWebsiteClick = { url ->
+                                IntentUtils.openUrl(context, url)
+                            },
+                            modifier = Modifier.padding(horizontal = Spacing.Medium)
+                        )
+
+                        Spacer(modifier = Modifier.height(Spacing.Medium))
+
+                        FollowingSection(
+                            users = state.followingList,
+                            selectedFilter = FollowingFilter.ALL,
+                            onFilterSelected = { },
+                            onUserClick = { user -> onNavigateToUserProfile(user.id) },
+                            onSeeAllClick = onNavigateToFollowing,
+                            modifier = Modifier.padding(horizontal = Spacing.Medium)
+                        )
+
+                        Spacer(modifier = Modifier.height(Spacing.Medium))
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/search/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/search/search/SearchScreen.kt
@@ -380,10 +380,9 @@ fun SearchScreen(
                         } // End else branch
                     } // End outer when
                 } // End SkeletonMorphedContent
-        } // End HorizontalPager Box
-    } // End HorizontalPager content
-} // End Column scope
-} // End Scaffold innerPadding scope
+            } // End HorizontalPager
+        } // End Column
+    } // End Scaffold
 
     selectedPost?.let { post ->
         PostOptionsBottomSheet(

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/search/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/search/search/SearchScreen.kt
@@ -44,6 +44,7 @@ import com.synapse.social.studioasinc.feature.shared.components.post.PostActions
 import com.synapse.social.studioasinc.feature.shared.components.post.PostOptionsBottomSheet
 import com.synapse.social.studioasinc.feature.shared.components.post.PostSummarySheet
 import com.synapse.social.studioasinc.feature.shared.components.post.SharedPostItem
+import com.synapse.social.studioasinc.core.ui.animation.SkeletonMorphedContent
 import com.synapse.social.studioasinc.ui.components.ExpressiveLoadingIndicator
 import com.synapse.social.studioasinc.ui.components.ShimmerBox
 import com.synapse.social.studioasinc.ui.components.ShimmerCircle
@@ -216,156 +217,67 @@ fun SearchScreen(
             ) { page ->
                 val tab = SearchTab.entries[page]
 
-                Box(modifier = Modifier.fillMaxSize()) {
-                    if (uiState.isLoading) {
-                        SearchLoadingShimmer()
-                    } else {
-                        when (tab) {
-                            SearchTab.FOR_YOU -> {
-                                if (uiState.posts.isEmpty() && uiState.accounts.isEmpty() && uiState.hashtags.isEmpty()) {
-                                    EmptyState(stringResource(R.string.no_content_found))
-                                } else {
-                                    LazyColumn(
-                                        modifier = Modifier.fillMaxSize(),
-                                        contentPadding = PaddingValues(Spacing.Medium),
-                                        verticalArrangement = Arrangement.spacedBy(Spacing.Medium)
-                                    ) {
-                                        items(uiState.hashtags) { hashtag ->
-                                            Card(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                shape = RoundedCornerShape(Spacing.Medium),
-                                                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
-                                            ) {
-                                                HashtagCard(
-                                                    hashtag = hashtag,
-                                                    onClick = { viewModel.onSearch(hashtag.tag) }
-                                                )
-                                            }
-                                        }
-                                        items(uiState.accounts) { account ->
-                                            Card(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                shape = RoundedCornerShape(Spacing.Medium),
-                                                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
-                                            ) {
-                                                AccountCard(
-                                                    account = account,
-                                                    onClick = { onNavigateToProfile(account.id) },
-                                                    onFollowClick = { viewModel.toggleFollow(account.id) }
-                                                )
-                                            }
-                                        }
-                                        items(uiState.posts) { post ->
-                                            val actions = remember(viewModel) {
-                                                PostActions(
-                                                    onLike = viewModel::likePost,
-                                                    onComment = { p -> onNavigateToPost(p.id) },
-                                                    onShare = viewModel::sharePost,
-                                                    onRepost = { },
-                                                    onQuote = { },
-                                                    onBookmark = viewModel::bookmarkPost,
-                                                    onOptionClick = { p -> selectedPost = p },
-                                                    onPollVote = viewModel::votePoll,
-                                                    onUserClick = { userId -> onNavigateToProfile(userId) },
-                                                    onMediaClick = { _ -> onNavigateToPost(post.id) },
-                                                    onReactionSelected = { p, r -> viewModel.reactToPost(p, r) }
-                                                )
-                                            }
-                                            Card(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                shape = RoundedCornerShape(Spacing.Medium),
-                                                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
-                                            ) {
-                                                SharedPostItem(
-                                                    post = post,
-                                                    actions = actions
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            else -> {
+                SkeletonMorphedContent(
+                    isLoading = uiState.isLoading,
+                    skeleton = { SearchLoadingShimmer() },
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    when (tab) {
+                        SearchTab.FOR_YOU -> {
+                            if (uiState.posts.isEmpty() && uiState.accounts.isEmpty() && uiState.hashtags.isEmpty()) {
+                                EmptyState(stringResource(R.string.no_content_found))
+                            } else {
                                 LazyColumn(
                                     modifier = Modifier.fillMaxSize(),
-                                    contentPadding = PaddingValues(bottom = Sizes.WidthLarge)
+                                    contentPadding = PaddingValues(Spacing.Medium),
+                                    verticalArrangement = Arrangement.spacedBy(Spacing.Medium)
                                 ) {
-                                    when (tab) {
-                                        SearchTab.FOR_YOU -> {} // Handled above
-                                SearchTab.PEOPLE -> {
-                                    if (uiState.accounts.isEmpty()) {
-                                        item { EmptyState(stringResource(R.string.no_accounts_found)) }
-                                    } else {
-                                        itemsIndexed(uiState.accounts, key = { index, it -> "${it.id}_${index}" }) { index, account ->
+                                    items(uiState.hashtags) { hashtag ->
+                                        Card(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            shape = RoundedCornerShape(Spacing.Medium),
+                                            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+                                        ) {
+                                            HashtagCard(
+                                                hashtag = hashtag,
+                                                onClick = { viewModel.onSearch(hashtag.tag) }
+                                            )
+                                        }
+                                    }
+                                    items(uiState.accounts) { account ->
+                                        Card(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            shape = RoundedCornerShape(Spacing.Medium),
+                                            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+                                        ) {
                                             AccountCard(
                                                 account = account,
                                                 onClick = { onNavigateToProfile(account.id) },
                                                 onFollowClick = { viewModel.toggleFollow(account.id) }
                                             )
-                                            HorizontalDivider(
-                                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                                                thickness = Sizes.BorderHairline
-                                            )
                                         }
                                     }
-                                }
-                                SearchTab.TRENDING, SearchTab.LISTS -> {
-                                    if (uiState.hashtags.isEmpty()) {
-                                        item { EmptyState(stringResource(R.string.no_hashtags_found)) }
-                                    } else {
-                                        itemsIndexed(uiState.hashtags, key = { index, it -> "${it.id}_${index}" }) { index, hashtag ->
-                                            HashtagCard(
-                                                hashtag = hashtag,
-                                                onClick = { viewModel.onSearch(hashtag.tag) }
-                                            )
-                                            HorizontalDivider(
-                                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                                                thickness = Sizes.BorderHairline
-                                            )
-                                        }
-                                    }
-                                }
-                                SearchTab.NEWS, SearchTab.SPORTS, SearchTab.ENTERTAINMENT -> {
-                                    if (uiState.news.isEmpty()) {
-                                        item { EmptyState(stringResource(R.string.no_news_found)) }
-                                    } else {
-                                        itemsIndexed(uiState.news, key = { index, it -> "${it.id}_${index}" }) { index, news ->
-                                            NewsCard(
-                                                news = news,
-                                                onClick = {
-                                                    news.url?.let { url ->
-                                                        IntentUtils.openUrl(context, url)
-                                                    }
-                                                }
-                                            )
-                                            HorizontalDivider(
-                                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                                                thickness = Sizes.BorderHairline
+                                    items(uiState.posts) { post ->
+                                        val actions = remember(viewModel) {
+                                            PostActions(
+                                                onLike = viewModel::likePost,
+                                                onComment = { p -> onNavigateToPost(p.id) },
+                                                onShare = viewModel::sharePost,
+                                                onRepost = { },
+                                                onQuote = { },
+                                                onBookmark = viewModel::bookmarkPost,
+                                                onOptionClick = { p -> selectedPost = p },
+                                                onPollVote = viewModel::votePoll,
+                                                onUserClick = { userId -> onNavigateToProfile(userId) },
+                                                onMediaClick = { _ -> onNavigateToPost(post.id) },
+                                                onReactionSelected = { p, r -> viewModel.reactToPost(p, r) }
                                             )
                                         }
-                                    }
-                                }
-                                SearchTab.TOP, SearchTab.LATEST, SearchTab.MEDIA -> {
-                                    if (uiState.posts.isEmpty()) {
-                                        item { EmptyState(stringResource(R.string.empty_posts_title)) }
-                                    } else {
-                                        itemsIndexed(uiState.posts, key = { index, it -> "${it.id}_${index}" }) { index, post ->
-                                            val actions = remember(viewModel) {
-                                                PostActions(
-                                                    onLike = viewModel::likePost,
-                                                    onComment = { p -> onNavigateToPost(p.id) },
-                                                    onShare = viewModel::sharePost,
-                                                    onRepost = { },
-                                                    onQuote = { },
-                                                    onBookmark = viewModel::bookmarkPost,
-                                                    onOptionClick = { p -> selectedPost = p },
-                                                    onPollVote = viewModel::votePoll,
-                                                    onUserClick = { userId -> onNavigateToProfile(userId) },
-                                                    onMediaClick = { _ -> onNavigateToPost(post.id) },
-                                                    onReactionSelected = { p, r -> viewModel.reactToPost(p, r) }
-                                                )
-                                            }
-
+                                        Card(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            shape = RoundedCornerShape(Spacing.Medium),
+                                            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+                                        ) {
                                             SharedPostItem(
                                                 post = post,
                                                 actions = actions
@@ -373,11 +285,101 @@ fun SearchScreen(
                                         }
                                     }
                                 }
-                            } // End inner when
-                        } // End LazyColumn
-                    } // End else branch
-                } // End outer when
-            } // End Box else
+                            }
+                        }
+                        else -> {
+                            LazyColumn(
+                                modifier = Modifier.fillMaxSize(),
+                                contentPadding = PaddingValues(bottom = Sizes.WidthLarge)
+                            ) {
+                                when (tab) {
+                                    SearchTab.FOR_YOU -> {} // Handled above
+                                    SearchTab.PEOPLE -> {
+                                        if (uiState.accounts.isEmpty()) {
+                                            item { EmptyState(stringResource(R.string.no_accounts_found)) }
+                                        } else {
+                                            itemsIndexed(uiState.accounts, key = { index, it -> "${it.id}_${index}" }) { index, account ->
+                                                AccountCard(
+                                                    account = account,
+                                                    onClick = { onNavigateToProfile(account.id) },
+                                                    onFollowClick = { viewModel.toggleFollow(account.id) }
+                                                )
+                                                HorizontalDivider(
+                                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                                    thickness = Sizes.BorderHairline
+                                                )
+                                            }
+                                        }
+                                    }
+                                    SearchTab.TRENDING, SearchTab.LISTS -> {
+                                        if (uiState.hashtags.isEmpty()) {
+                                            item { EmptyState(stringResource(R.string.no_hashtags_found)) }
+                                        } else {
+                                            itemsIndexed(uiState.hashtags, key = { index, it -> "${it.id}_${index}" }) { index, hashtag ->
+                                                HashtagCard(
+                                                    hashtag = hashtag,
+                                                    onClick = { viewModel.onSearch(hashtag.tag) }
+                                                )
+                                                HorizontalDivider(
+                                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                                    thickness = Sizes.BorderHairline
+                                                )
+                                            }
+                                        }
+                                    }
+                                    SearchTab.NEWS, SearchTab.SPORTS, SearchTab.ENTERTAINMENT -> {
+                                        if (uiState.news.isEmpty()) {
+                                            item { EmptyState(stringResource(R.string.no_news_found)) }
+                                        } else {
+                                            itemsIndexed(uiState.news, key = { index, it -> "${it.id}_${index}" }) { index, news ->
+                                                NewsCard(
+                                                    news = news,
+                                                    onClick = {
+                                                        news.url?.let { url ->
+                                                            IntentUtils.openUrl(context, url)
+                                                        }
+                                                    }
+                                                )
+                                                HorizontalDivider(
+                                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                                    thickness = Sizes.BorderHairline
+                                                )
+                                            }
+                                        }
+                                    }
+                                    SearchTab.TOP, SearchTab.LATEST, SearchTab.MEDIA -> {
+                                        if (uiState.posts.isEmpty()) {
+                                            item { EmptyState(stringResource(R.string.empty_posts_title)) }
+                                        } else {
+                                            itemsIndexed(uiState.posts, key = { index, it -> "${it.id}_${index}" }) { index, post ->
+                                                val actions = remember(viewModel) {
+                                                    PostActions(
+                                                        onLike = viewModel::likePost,
+                                                        onComment = { p -> onNavigateToPost(p.id) },
+                                                        onShare = viewModel::sharePost,
+                                                        onRepost = { },
+                                                        onQuote = { },
+                                                        onBookmark = viewModel::bookmarkPost,
+                                                        onOptionClick = { p -> selectedPost = p },
+                                                        onPollVote = viewModel::votePoll,
+                                                        onUserClick = { userId -> onNavigateToProfile(userId) },
+                                                        onMediaClick = { _ -> onNavigateToPost(post.id) },
+                                                        onReactionSelected = { p, r -> viewModel.reactToPost(p, r) }
+                                                    )
+                                                }
+
+                                                SharedPostItem(
+                                                    post = post,
+                                                    actions = actions
+                                                )
+                                            }
+                                        }
+                                    }
+                                } // End inner when
+                            } // End LazyColumn
+                        } // End else branch
+                    } // End outer when
+                } // End SkeletonMorphedContent
         } // End HorizontalPager Box
     } // End HorizontalPager content
 } // End Column scope


### PR DESCRIPTION
Implemented a smooth "morphing" transition between skeleton/shimmer states and actual content in Search and Profile screens.

Key additions:
- `SkeletonMorphedContent` component: A reusable wrapper that handles the transition logic using Compose's `AnimatedContent`.
- Integrated this component into `SearchScreen` and `ProfileContentSection`.

This addresses the requirement for a more fluid UX when data finishes loading, replacing "pop-ins" with a coordinated cross-fade and scale effect.

Fixes #135

---
*PR created automatically by Jules for task [9939980654132345466](https://jules.google.com/task/9939980654132345466) started by @TheRealAshik*