### PR TITLE
✨ feat: Add liquid message settling animation to Android and iOS Message Bubbles

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
@@ -1,6 +1,7 @@
 package com.synapse.social.studioasinc.feature.inbox.inbox.components
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -215,6 +216,55 @@ fun UnreadDividerRow(count: Int) {
     }
 }
 
+
+class LiquidMessageShape(
+    private val progress: Float,
+    private val isFromMe: Boolean,
+    private val cornerRadiusPx: Float,
+    private val sharpRadiusPx: Float,
+    private val position: GroupPosition
+) : androidx.compose.ui.graphics.Shape {
+    override fun createOutline(size: androidx.compose.ui.geometry.Size, layoutDirection: androidx.compose.ui.unit.LayoutDirection, density: androidx.compose.ui.unit.Density): androidx.compose.ui.graphics.Outline {
+        val path = androidx.compose.ui.graphics.Path()
+
+        val startSize = 100f // roughly 36.dp
+
+        val tl = if (isFromMe || position == GroupPosition.MIDDLE || position == GroupPosition.LAST) cornerRadiusPx else sharpRadiusPx
+        val tr = if (!isFromMe || position == GroupPosition.MIDDLE || position == GroupPosition.LAST) cornerRadiusPx else sharpRadiusPx
+        val bl = if (isFromMe || position == GroupPosition.MIDDLE || position == GroupPosition.FIRST) cornerRadiusPx else sharpRadiusPx
+        val br = if (!isFromMe || position == GroupPosition.MIDDLE || position == GroupPosition.FIRST) cornerRadiusPx else sharpRadiusPx
+
+        val currentWidth = lerp(startSize, size.width, progress)
+        val currentHeight = lerp(startSize, size.height, progress)
+
+        val offsetX = if (isFromMe) size.width - currentWidth else 0f
+        val offsetY = size.height - currentHeight
+
+        val cTl = androidx.compose.ui.geometry.CornerRadius(lerp(startSize / 2f, tl, progress))
+        val cTr = androidx.compose.ui.geometry.CornerRadius(lerp(startSize / 2f, tr, progress))
+        val cBl = androidx.compose.ui.geometry.CornerRadius(lerp(startSize / 2f, bl, progress))
+        val cBr = androidx.compose.ui.geometry.CornerRadius(lerp(startSize / 2f, br, progress))
+
+        val roundRect = androidx.compose.ui.geometry.RoundRect(
+            left = offsetX,
+            top = offsetY,
+            right = offsetX + currentWidth,
+            bottom = offsetY + currentHeight,
+            topLeftCornerRadius = cTl,
+            topRightCornerRadius = cTr,
+            bottomRightCornerRadius = cBr,
+            bottomLeftCornerRadius = cBl
+        )
+
+        path.addRoundRect(roundRect)
+        return androidx.compose.ui.graphics.Outline.Generic(path)
+    }
+
+    private fun lerp(start: Float, stop: Float, fraction: Float): Float {
+        return start + (stop - start) * fraction
+    }
+}
+
 enum class GroupPosition {
     SINGLE, FIRST, MIDDLE, LAST
 }
@@ -288,21 +338,27 @@ fun MessageBubble(
 
     // UI logic applied carefully matching sender side for sharpness:
     val radius = cornerRadius.dp
-    val shape = if (isFromMe) {
-        when (position) {
-            GroupPosition.SINGLE -> RoundedCornerShape(radius, radius, radius, radius)
-            GroupPosition.FIRST -> RoundedCornerShape(radius, radius, Sizes.CornerSharp, radius)
-            GroupPosition.MIDDLE -> RoundedCornerShape(radius, Sizes.CornerSharp, Sizes.CornerSharp, radius)
-            GroupPosition.LAST -> RoundedCornerShape(radius, Sizes.CornerSharp, radius, radius)
-        }
-    } else {
-        when (position) {
-            GroupPosition.SINGLE -> RoundedCornerShape(radius, radius, radius, radius)
-            GroupPosition.FIRST -> RoundedCornerShape(radius, radius, radius, Sizes.CornerSharp)
-            GroupPosition.MIDDLE -> RoundedCornerShape(Sizes.CornerSharp, radius, radius, Sizes.CornerSharp)
-            GroupPosition.LAST -> RoundedCornerShape(Sizes.CornerSharp, radius, radius, radius)
-        }
+
+    var isVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        isVisible = true
     }
+    val morphProgress by animateFloatAsState(
+        targetValue = if (isVisible) 1f else 0f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "liquid_morph"
+    )
+
+    val shape = LiquidMessageShape(
+        progress = morphProgress,
+        isFromMe = isFromMe,
+        cornerRadiusPx = with(LocalDensity.current) { radius.toPx() },
+        sharpRadiusPx = with(LocalDensity.current) { Sizes.CornerSharp.toPx() },
+        position = position
+    )
 
     val offsetX = remember { Animatable(0f) }
     val coroutineScope = rememberCoroutineScope()

--- a/iosApp/iosApp/Chat/Components/MessageBubbleView.swift
+++ b/iosApp/iosApp/Chat/Components/MessageBubbleView.swift
@@ -1,10 +1,44 @@
 import SwiftUI
 import shared
 
+
+struct LiquidMessageShape: Shape {
+    var progress: CGFloat
+    var isFromMe: Bool
+    var cornerRadius: CGFloat
+
+    var animatableData: CGFloat {
+        get { progress }
+        set { progress = newValue }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+
+        let startSize: CGFloat = 36.0
+
+        let currentW = startSize + (rect.width - startSize) * progress
+        let currentH = startSize + (rect.height - startSize) * progress
+
+        let x = isFromMe ? rect.maxX - currentW : rect.minX
+        let y = rect.maxY - currentH // Anchor to bottom
+
+        let currentRadius = (startSize / 2.0) + (cornerRadius - startSize / 2.0) * progress
+
+        let rRect = CGRect(x: x, y: y, width: currentW, height: currentH)
+
+        path.addRoundedRect(in: rRect, cornerSize: CGSize(width: currentRadius, height: currentRadius))
+
+        return path
+    }
+}
+
 struct MessageBubbleView: View {
     let message: SwiftMessage
     let isFromMe: Bool
     var onReactionSelected: ((shared.ReactionType) -> Void)? = nil
+
+    @State private var appearProgress: CGFloat = 0.0
 
     var body: some View {
         HStack {
@@ -25,7 +59,7 @@ struct MessageBubbleView: View {
                             .overlay(ProgressView())
                     }
                     .frame(maxWidth: 250)
-                    .cornerRadius(12)
+                    .clipShape(LiquidMessageShape(progress: appearProgress, isFromMe: isFromMe, cornerRadius: 12))
                 }
 
                 if !message.content.isEmpty {
@@ -33,7 +67,7 @@ struct MessageBubbleView: View {
                         .padding(12)
                         .foregroundColor(isFromMe ? .white : .primary)
                         .background(isFromMe ? Color.blue : Color(UIColor.secondarySystemBackground))
-                        .cornerRadius(16)
+                        .clipShape(LiquidMessageShape(progress: appearProgress, isFromMe: isFromMe, cornerRadius: 16))
                 }
 
                 if !message.reactions.isEmpty {
@@ -80,7 +114,14 @@ struct MessageBubbleView: View {
                 Spacer()
             }
         }
+
         .padding(.horizontal, 4)
+        .onAppear {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.5, blendDuration: 0)) {
+                appearProgress = 1.0
+            }
+        }
+
     }
 
     private func formatTime(_ timeStr: String) -> String {


### PR DESCRIPTION
Implements a custom "Liquid Drop" shape that morphs between a circular drop and the standard rounded rectangle shape for chat message bubbles on both Android (Compose) and iOS (SwiftUI). Driven by a spring animation.

---
*PR created automatically by Jules for task [814046899213089369](https://jules.google.com/task/814046899213089369) started by @TheRealAshik*