### PR TITLE
✨ feat: Time-Capsule Threads - Delayed Engagement & Anticipation-Based Social

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/core/di/PostModule.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/core/di/PostModule.kt
@@ -71,6 +71,8 @@ import com.synapse.social.studioasinc.shared.domain.usecase.notification.MarkNot
 import com.synapse.social.studioasinc.shared.domain.usecase.notification.SubscribeToNotificationsUseCase
 import com.synapse.social.studioasinc.shared.domain.usecase.post.DeletePostUseCase
 import com.synapse.social.studioasinc.shared.domain.usecase.post.TogglePostCommentsUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.post.CreateTimeCapsuleUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.post.GetTimeCapsuleStatusUseCase
 import com.synapse.social.studioasinc.shared.domain.usecase.user.GetCurrentUserAvatarUseCase
 import com.synapse.social.studioasinc.shared.domain.usecase.user.GetUserProfileUseCase
 import com.synapse.social.studioasinc.shared.domain.usecase.user.SearchUsersUseCase
@@ -221,6 +223,22 @@ object PostModule {
         repository: PostActionsRepository
     ): DeletePostUseCase {
         return DeletePostUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideCreateTimeCapsuleUseCase(
+        repository: PostActionsRepository
+    ): CreateTimeCapsuleUseCase {
+        return CreateTimeCapsuleUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideGetTimeCapsuleStatusUseCase(
+        repository: PostActionsRepository
+    ): GetTimeCapsuleStatusUseCase {
+        return GetTimeCapsuleStatusUseCase(repository)
     }
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/PostDtos.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/PostDtos.kt
@@ -44,7 +44,10 @@ data class PostInsertDto(
     @SerialName("location_place_id") val locationPlaceId: String? = null,
     @SerialName("youtube_url") val youtubeUrl: String? = null,
     @SerialName("link_previews") val linkPreviews: List<LinkPreview>? = null,
-    @SerialName("metadata") val metadata: PostMetadata? = null
+    @SerialName("metadata") val metadata: PostMetadata? = null,
+    @SerialName("is_time_capsule") val isTimeCapsule: Boolean = false,
+    @SerialName("unlocks_at") val unlocksAt: Long? = null,
+    @SerialName("capsule_state") val capsuleState: String? = "OPENED"
 )
 
 @Serializable
@@ -104,6 +107,9 @@ data class PostSelectDto(
     @SerialName("youtube_url") val youtubeUrl: String? = null,
     @SerialName("link_previews") val linkPreviews: List<LinkPreview>? = null,
     @SerialName("metadata") val metadata: PostMetadata? = null,
+    @SerialName("is_time_capsule") val isTimeCapsule: Boolean = false,
+    @SerialName("unlocks_at") val unlocksAt: Long? = null,
+    @SerialName("capsule_state") val capsuleState: String? = "OPENED",
     @SerialName("quoted_post") val quotedPost: PostSelectDto? = null,
     @SerialName("quoted_post_id") val quotedPostId: String? = null,
     @SerialName("is_quote") val isQuote: Boolean = false,
@@ -152,7 +158,10 @@ fun Post.toInsertDto(): PostInsertDto {
         locationPlaceId = this.locationPlaceId,
         youtubeUrl = this.youtubeUrl,
         linkPreviews = this.linkPreviews,
-        metadata = this.metadata
+        metadata = this.metadata,
+        isTimeCapsule = this.isTimeCapsule,
+        unlocksAt = this.unlocksAt,
+        capsuleState = this.capsuleState
     )
 }
 
@@ -192,7 +201,10 @@ fun Post.toUpdateDto(): PostInsertDto {
         locationPlaceId = this.locationPlaceId,
         youtubeUrl = this.youtubeUrl,
         linkPreviews = this.linkPreviews,
-        metadata = this.metadata
+        metadata = this.metadata,
+        isTimeCapsule = this.isTimeCapsule,
+        unlocksAt = this.unlocksAt,
+        capsuleState = this.capsuleState
     )
 }
 
@@ -236,6 +248,9 @@ fun PostSelectDto.toDomain(constructMediaUrl: (String) -> String, constructAvata
         youtubeUrl = this.youtubeUrl,
         linkPreviews = this.linkPreviews,
         metadata = this.metadata,
+        isTimeCapsule = this.isTimeCapsule,
+        unlocksAt = this.unlocksAt,
+        capsuleState = this.capsuleState,
         quotedPostId = this.quotedPostId,
         isQuote = this.isQuote,
         quotedPost = this.quotedPost?.toDomain(constructMediaUrl, constructAvatarUrl)

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/PostMapper.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/PostMapper.kt
@@ -68,7 +68,10 @@ object PostMapper {
             metadata = post.metadata?.let { toSharedPostMetadata(it) },
             quotedPostId = post.quotedPostId,
             isQuote = post.isQuote,
-            rootPostId = post.rootPostId
+            rootPostId = post.rootPostId,
+            isTimeCapsule = post.isTimeCapsule,
+            unlocksAt = post.unlocksAt,
+            capsuleState = post.capsuleState
         )
     }
 
@@ -125,7 +128,10 @@ object PostMapper {
             metadata = entity.metadata?.let { toAppPostMetadata(it) },
             quotedPostId = entity.quotedPostId,
             isQuote = entity.isQuote,
-            rootPostId = entity.rootPostId
+            rootPostId = entity.rootPostId,
+            isTimeCapsule = entity.isTimeCapsule,
+            unlocksAt = entity.unlocksAt,
+            capsuleState = entity.capsuleState
         )
     }
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/CreatePostRequest.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/CreatePostRequest.kt
@@ -18,5 +18,7 @@ data class CreatePostRequest(
     val disableComments: Boolean = false,
     val isEditMode: Boolean = false,
     val editPostId: String? = null,
-    val replyToPostId: String? = null
+    val replyToPostId: String? = null,
+    val isTimeCapsule: Boolean = false,
+    val unlocksAt: Long? = null
 )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/Post.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/Post.kt
@@ -191,7 +191,14 @@ data class Post(
     val resharedByUsername: String? = null,
 
     @SerialName("metadata")
-    val metadata: PostMetadata? = null
+    val metadata: PostMetadata? = null,
+
+    @SerialName("is_time_capsule")
+    val isTimeCapsule: Boolean = false,
+    @SerialName("unlocks_at")
+    val unlocksAt: Long? = null,
+    @SerialName("capsule_state")
+    val capsuleState: String? = "OPENED"
 ) {
     fun determinePostType() {
         postType = when {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/domain/usecase/post/SubmitPostUseCase.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/domain/usecase/post/SubmitPostUseCase.kt
@@ -127,7 +127,10 @@ class SubmitPostUseCase @Inject constructor(
                     postImage = mediaItems.firstOrNull { it.type == MediaType.IMAGE }?.url,
                     username = username,
                     avatarUrl = avatarUrl,
-                    isVerified = isVerified
+                    isVerified = isVerified,
+                    isTimeCapsule = request.isTimeCapsule,
+                    unlocksAt = request.unlocksAt,
+                    capsuleState = if (request.isTimeCapsule) "LOCKED" else "OPENED"
                 )
                 postsToCreate.add(post)
                 previousPostId = postId
@@ -211,7 +214,10 @@ class SubmitPostUseCase @Inject constructor(
                     taggedPeople = request.taggedPeople.ifEmpty { null }?.map { com.synapse.social.studioasinc.domain.model.User(uid = it) },
                     feeling = null,
                     backgroundColor = request.textBackgroundColor
-                )
+                ),
+                isTimeCapsule = request.isTimeCapsule,
+                unlocksAt = request.unlocksAt,
+                capsuleState = if (request.isTimeCapsule) "LOCKED" else "OPENED"
             )
 
             val newMedia = request.mediaItems.filter { !it.url.startsWith("http") }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/createpost/createpost/CreatePostContent.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/createpost/createpost/CreatePostContent.kt
@@ -31,6 +31,10 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.foundation.clickable
 
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
@@ -45,6 +49,73 @@ import com.synapse.social.studioasinc.R
 import com.synapse.social.studioasinc.ui.createpost.CreatePostSearchUiState
 import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 import com.synapse.social.studioasinc.feature.shared.theme.Sizes
+
+@Composable
+fun TimeCapsuleToggle(
+    isTimeCapsule: Boolean,
+    unlocksAt: Long?,
+    onToggle: (Boolean) -> Unit,
+    onSelectUnlockDate: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(Spacing.Medium)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.time_capsule),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = stringResource(R.string.time_capsule_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = isTimeCapsule,
+                    onCheckedChange = onToggle
+                )
+            }
+
+            if (isTimeCapsule) {
+                Spacer(modifier = Modifier.height(Spacing.Small))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onSelectUnlockDate() }
+                        .padding(vertical = Spacing.Small),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.unlock_date),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Text(
+                        text = if (unlocksAt != null) {
+                            java.text.DateFormat.getDateTimeInstance().format(java.util.Date(unlocksAt))
+                        } else {
+                            "Select date"
+                        },
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+}
 
 @Composable
 fun CreatePostContent(
@@ -65,7 +136,9 @@ fun CreatePostContent(
     onUpdateThreadText: (Int, String) -> Unit,
     onRemoveThreadMedia: (Int, Int) -> Unit,
     onEditThreadMedia: (Int, Int) -> Unit,
-    onAddThreadMedia: (Int) -> Unit
+    onAddThreadMedia: (Int) -> Unit,
+    onTimeCapsuleToggle: (Boolean) -> Unit,
+    onSelectUnlockDate: () -> Unit
 ) {
     LazyColumn(
         modifier = Modifier
@@ -142,6 +215,15 @@ fun CreatePostContent(
                     }
                 }
             }
+        }
+
+        item {
+            TimeCapsuleToggle(
+                isTimeCapsule = uiState.isTimeCapsule,
+                unlocksAt = uiState.unlocksAt,
+                onToggle = onTimeCapsuleToggle,
+                onSelectUnlockDate = onSelectUnlockDate
+            )
         }
 
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/createpost/createpost/CreatePostScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/createpost/createpost/CreatePostScreen.kt
@@ -75,6 +75,54 @@ fun CreatePostScreen(
     var locationSearchQuery by remember { mutableStateOf("") }
     var feelingSearchQuery by remember { mutableStateOf("") }
 
+    var showDatePicker by remember { mutableStateOf(false) }
+    var showTimePicker by remember { mutableStateOf(false) }
+    val datePickerState = rememberDatePickerState()
+    val timePickerState = rememberTimePickerState()
+
+    if (showDatePicker) {
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDatePicker = false
+                    showTimePicker = true
+                }) {
+                    Text("Next")
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    if (showTimePicker) {
+        AlertDialog(
+            onDismissRequest = { showTimePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    val calendar = java.util.Calendar.getInstance()
+                    datePickerState.selectedDateMillis?.let {
+                        calendar.timeInMillis = it
+                        calendar.set(java.util.Calendar.HOUR_OF_DAY, timePickerState.hour)
+                        calendar.set(java.util.Calendar.MINUTE, timePickerState.minute)
+
+                        val selectedTime = calendar.timeInMillis
+                        if (selectedTime > System.currentTimeMillis()) {
+                            viewModel.setUnlocksAt(selectedTime)
+                        } else {
+                            Toast.makeText(context, context.getString(R.string.error_unlock_future), Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                    showTimePicker = false
+                }) {
+                    Text("OK")
+                }
+            },
+            title = { Text("Select Time") },
+            text = { TimePicker(state = timePickerState) }
+        )
+    }
 
     LaunchedEffect(true) {
         viewModel.loadDraft()
@@ -234,7 +282,9 @@ fun CreatePostScreen(
                 onAddThreadMedia = { postIndex ->
                     threadMediaPickerIndex = postIndex
                     threadMediaLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageAndVideo))
-                }
+                },
+                onTimeCapsuleToggle = { viewModel.toggleTimeCapsule(it) },
+                onSelectUnlockDate = { showDatePicker = true }
             )
         }
     }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/createpost/createpost/CreatePostViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/createpost/createpost/CreatePostViewModel.kt
@@ -74,6 +74,9 @@ data class CreatePostUiState(
     val threadPosts: List<PostDraft> = emptyList(),
     val currentUserProfile: User? = null,
 
+    val isTimeCapsule: Boolean = false,
+    val unlocksAt: Long? = null,
+
     val taggedPeople: List<User> = emptyList(),
     val feeling: FeelingActivity? = null,
     val textBackgroundColor: Long? = null,
@@ -395,6 +398,14 @@ class CreatePostViewModel @Inject constructor(
         _uiState.update { it.copy(privacy = privacy) }
     }
 
+    fun toggleTimeCapsule(enabled: Boolean) {
+        _uiState.update { it.copy(isTimeCapsule = enabled) }
+    }
+
+    fun setUnlocksAt(timestamp: Long?) {
+        _uiState.update { it.copy(unlocksAt = timestamp) }
+    }
+
     fun updateSettings(settings: PostSettings) {
         _uiState.update { it.copy(settings = settings) }
     }
@@ -488,6 +499,8 @@ class CreatePostViewModel @Inject constructor(
                 hideCommentsCount = state.settings.hideCommentsCount,
                 disableComments = state.settings.disableComments,
                 isEditMode = state.isEditMode,
+                isTimeCapsule = state.isTimeCapsule,
+                unlocksAt = state.unlocksAt,
                 editPostId = editPostId,
                 replyToPostId = state.replyToPostId
             )
@@ -550,7 +563,9 @@ class CreatePostViewModel @Inject constructor(
                             hideViewsCount = state.settings.hideViewsCount,
                             hideLikeCount = state.settings.hideLikeCount,
                             hideCommentsCount = state.settings.hideCommentsCount,
-                            disableComments = state.settings.disableComments
+                            disableComments = state.settings.disableComments,
+                            isTimeCapsule = state.isTimeCapsule,
+                            unlocksAt = state.unlocksAt
                         ))
                     }
                 }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailUiState.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailUiState.kt
@@ -24,5 +24,7 @@ data class PostDetailUiState(
     val ancestorComments: List<CommentWithUser> = emptyList(),
     val postSummary: String? = null,
     val isSummarizing: Boolean = false,
-    val summaryError: String? = null
+    val summaryError: String? = null,
+    val capsuleRemainingTime: Long = 0L,
+    val isCapsuleLocked: Boolean = false
 )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailViewModel.kt
@@ -30,6 +30,7 @@ import javax.inject.Inject
 import com.synapse.social.studioasinc.core.util.NotificationHelper
 import com.synapse.social.studioasinc.domain.usecase.ai.SummarizePostUseCase
 import com.synapse.social.studioasinc.domain.usecase.ai.SummarizeThreadUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.post.GetTimeCapsuleStatusUseCase
 
 @HiltViewModel
 class PostDetailViewModel @Inject constructor(
@@ -47,7 +48,8 @@ class PostDetailViewModel @Inject constructor(
     private val postActionsRepository: PostActionsRepository,
     private val blockUserUseCase: BlockUserUseCase,
     private val summarizePostUseCase: SummarizePostUseCase,
-    private val summarizeThreadUseCase: SummarizeThreadUseCase
+    private val summarizeThreadUseCase: SummarizeThreadUseCase,
+    private val getTimeCapsuleStatusUseCase: GetTimeCapsuleStatusUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(PostDetailUiState())
@@ -68,6 +70,7 @@ class PostDetailViewModel @Inject constructor(
 
     private var currentPostId: String? = null
     private var rootCommentId: String? = null
+    private var capsuleTimerJob: kotlinx.coroutines.Job? = null
 
     init {
         viewModelScope.launch {
@@ -92,6 +95,7 @@ class PostDetailViewModel @Inject constructor(
             postDetailRepository.getPostWithDetails(postId).fold(
                 onSuccess = { post ->
                     _uiState.update { it.copy(post = post) }
+                    startCapsuleTimer(post.post)
 
                     if (rootCommentId != null) {
                         commentRepository.getComment(rootCommentId).onSuccess { comment ->
@@ -482,5 +486,33 @@ class PostDetailViewModel @Inject constructor(
 
     fun clearPostSummary() {
         _uiState.update { it.copy(postSummary = null, summaryError = null) }
+    }
+
+    private fun startCapsuleTimer(post: Post) {
+        capsuleTimerJob?.cancel()
+        if (!post.isTimeCapsule || post.unlocksAt == null) {
+            _uiState.update { it.copy(isCapsuleLocked = false, capsuleRemainingTime = 0) }
+            return
+        }
+
+        capsuleTimerJob = viewModelScope.launch {
+            while (true) {
+                val remaining = getTimeCapsuleStatusUseCase(post.unlocksAt)
+                val isLocked = getTimeCapsuleStatusUseCase.isLocked(post.unlocksAt)
+
+                _uiState.update { it.copy(
+                    capsuleRemainingTime = remaining,
+                    isCapsuleLocked = isLocked
+                )}
+
+                if (!isLocked) break
+                kotlinx.coroutines.delay(1000)
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        capsuleTimerJob?.cancel()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1758,4 +1758,10 @@ Please explain the following message from %3$s in detail, considering the contex
     <string name="remove_credentials">Remove %1$s credentials</string>
     <string name="collapse_configuration">Collapse %1$s configuration</string>
     <string name="expand_configuration">Expand %1$s configuration</string>
+    <string name="time_capsule">Time Capsule</string>
+    <string name="time_capsule_hint">Locked until specified time</string>
+    <string name="unlock_date">Unlock Date</string>
+    <string name="error_unlock_future">Unlock date must be in the future</string>
+    <string name="capsule_locked_title">Time Capsule Locked</string>
+    <string name="capsule_locked_desc">Replies will be revealed in %s</string>
 </resources>

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/local/database/SqlDelightPostDao.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/local/database/SqlDelightPostDao.kt
@@ -124,7 +124,10 @@ class SqlDelightPostDao(
             metadata = dbPost.metadata,
             quotedPostId = dbPost.quotedPostId,
             isQuote = dbPost.isQuote,
-            rootPostId = dbPost.rootPostId
+            rootPostId = dbPost.rootPostId,
+            isTimeCapsule = dbPost.isTimeCapsule,
+            unlocksAt = dbPost.unlocksAt,
+            capsuleState = dbPost.capsuleState
         )
     }
 
@@ -180,7 +183,10 @@ class SqlDelightPostDao(
             metadata = entity.metadata,
             quotedPostId = entity.quotedPostId,
             isQuote = entity.isQuote,
-            rootPostId = entity.rootPostId
+            rootPostId = entity.rootPostId,
+            isTimeCapsule = entity.isTimeCapsule,
+            unlocksAt = entity.unlocksAt,
+            capsuleState = entity.capsuleState
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/local/entity/PostEntity.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/local/entity/PostEntity.kt
@@ -57,5 +57,8 @@ data class PostEntity(
     val metadata: PostMetadata?,
     val quotedPostId: String?,
     val isQuote: Boolean,
-    val rootPostId: String?
+    val rootPostId: String?,
+    val isTimeCapsule: Boolean,
+    val unlocksAt: Long?,
+    val capsuleState: String?
 )

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/post/CreateTimeCapsuleUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/post/CreateTimeCapsuleUseCase.kt
@@ -1,0 +1,13 @@
+package com.synapse.social.studioasinc.shared.domain.usecase.post
+
+import com.synapse.social.studioasinc.shared.domain.repository.PostActionsRepository
+import kotlinx.datetime.Clock
+
+class CreateTimeCapsuleUseCase(
+    private val repository: PostActionsRepository
+) {
+    fun validateUnlockDate(unlocksAt: Long): Boolean {
+        val now = Clock.System.now().toEpochMilliseconds()
+        return unlocksAt > now
+    }
+}

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/post/GetTimeCapsuleStatusUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/post/GetTimeCapsuleStatusUseCase.kt
@@ -1,0 +1,20 @@
+package com.synapse.social.studioasinc.shared.domain.usecase.post
+
+import com.synapse.social.studioasinc.shared.domain.repository.PostActionsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.datetime.Clock
+
+class GetTimeCapsuleStatusUseCase(
+    private val repository: PostActionsRepository
+) {
+    operator fun invoke(unlocksAt: Long): Long {
+        val now = Clock.System.now().toEpochMilliseconds()
+        return (unlocksAt - now).coerceAtLeast(0L)
+    }
+
+    fun isLocked(unlocksAt: Long): Boolean {
+        val now = Clock.System.now().toEpochMilliseconds()
+        return now < unlocksAt
+    }
+}

--- a/shared/src/commonMain/sqldelight/com/synapse/social/studioasinc/shared/data/database/Post.sq
+++ b/shared/src/commonMain/sqldelight/com/synapse/social/studioasinc/shared/data/database/Post.sq
@@ -60,7 +60,10 @@ CREATE TABLE Post (
     metadata TEXT AS PostMetadata,
     quotedPostId TEXT,
     isQuote INTEGER AS Boolean NOT NULL DEFAULT 0,
-    rootPostId TEXT
+    rootPostId TEXT,
+    isTimeCapsule INTEGER AS Boolean NOT NULL DEFAULT 0,
+    unlocksAt INTEGER,
+    capsuleState TEXT DEFAULT 'OPENED'
 );
 
 insertPost:
@@ -72,7 +75,7 @@ INSERT OR REPLACE INTO Post(
     hasPoll, pollQuestion, pollOptions, pollEndTime, pollAllowMultiple,
     hasLocation, locationName, locationAddress, locationLatitude, locationLongitude, locationPlaceId,
     youtubeUrl, reactions, userReaction, username, displayName, avatarUrl, isVerified, userPollVote, metadata,
-    quotedPostId, isQuote, rootPostId
+    quotedPostId, isQuote, rootPostId, isTimeCapsule, unlocksAt, capsuleState
 ) VALUES ?;
 
 selectAll:


### PR DESCRIPTION
This PR implements the "Time-Capsule Threads" feature. 

Key changes:
1. **Schema Update**: Added `isTimeCapsule` (Boolean), `unlocksAt` (Long), and `capsuleState` (String) to the Post table and entities.
2. **Domain Logic**: Added use cases for validating unlock dates and checking capsule status.
3. **Creation Flow**: Added a "Time Capsule" toggle in the post creation screen. Users can now select a future date and time for the capsule to open.
4. **Post Detail**: Updated the view model to track the countdown to the unlock time.
5. **Persistence**: Updated mappers and DTOs to ensure time capsule data is correctly synced with the Supabase backend.

Note: The "Breaking the Seal" reveal animation and Supabase RLS/Edge Function for automatic state transition should be implemented in subsequent tasks as they require backend/animation-specific polish.

---
*PR created automatically by Jules for task [6753387603456477448](https://jules.google.com/task/6753387603456477448) started by @TheRealAshik*