### PR TITLE
fix: real-time updates and keyboard auto-closing

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatInputBar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatInputBar.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.runtime.*
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalDensity
 import kotlin.random.Random
 import androidx.compose.ui.Alignment
@@ -87,6 +89,7 @@ fun ChatInputBar(
         label = "micScale"
     )
 
+    val focusRequester = remember { FocusRequester() }
     var isFocused by remember { mutableStateOf(false) }
     val isImeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
     val inputWidthFraction by animateFloatAsState(
@@ -192,6 +195,7 @@ fun ChatInputBar(
                         onClick = {
                             onInputTextChange(reply)
                             onSendMessage()
+                                        focusRequester.requestFocus()
                         },
                         label = { Text(reply) },
                         leadingIcon = {
@@ -390,7 +394,7 @@ fun ChatInputBar(
                 BasicTextField(
                     value = inputText,
                     onValueChange = onInputTextChange,
-                    modifier = Modifier
+                    modifier = Modifier.focusRequester(focusRequester)
                         .weight(1f)
                         .padding(horizontal = Spacing.Small)
                         .onFocusChanged { isFocused = it.isFocused },
@@ -481,6 +485,7 @@ fun ChatInputBar(
                                 onTap = {
                                     if (inputText.isNotEmpty()) {
                                         onSendMessage()
+                                        focusRequester.requestFocus()
                                         dismissedPreviewUrl = null
                                     }
                                 }

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/core/network/SupabaseClient.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/core/network/SupabaseClient.kt
@@ -1,16 +1,21 @@
 package com.synapse.social.studioasinc.shared.core.network
 
 import com.synapse.social.studioasinc.shared.core.config.SynapseConfig
+import com.synapse.social.studioasinc.shared.core.util.AppDispatchers
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.realtime.Realtime
+import io.github.jan.supabase.realtime.realtime
 import io.github.jan.supabase.storage.Storage
 import io.github.jan.supabase.functions.Functions
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.aakira.napier.Napier
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.http.Url
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 import io.github.jan.supabase.serializer.KotlinXSerializer
 import kotlinx.serialization.json.Json
@@ -24,6 +29,8 @@ object SupabaseClient {
     const val BUCKET_POST_MEDIA = "posts"
     const val BUCKET_USER_AVATARS = "avatars"
     const val BUCKET_USER_COVERS = "covers"
+
+    private val clientScope = CoroutineScope(AppDispatchers.IO + SupervisorJob())
 
     @OptIn(SupabaseInternal::class)
     val client by lazy {
@@ -57,6 +64,16 @@ object SupabaseClient {
                         requestTimeoutMillis = 300_000
                         connectTimeoutMillis = 60_000
                         socketTimeoutMillis = 300_000
+                    }
+                }
+            }.also {
+                // Automatically connect to Realtime when client is first initialized
+                clientScope.launch {
+                    try {
+                        it.realtime.connect()
+                        Napier.d("Realtime connected successfully", tag = TAG)
+                    } catch (e: Exception) {
+                        Napier.e("Failed to connect to Realtime automatically", e, tag = TAG)
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/ChatRealtimeDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/ChatRealtimeDataSource.kt
@@ -84,7 +84,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
             yield()
             try {
                 val status = channel.status.value
-                if (status == RealtimeChannel.Status.UNSUBSCRIBED || status == RealtimeChannel.Status.UNSUBSCRIBED) {
+                if (status == RealtimeChannel.Status.UNSUBSCRIBED) {
                     channel.subscribe()
                 } else {
                     Napier.w("Channel $channelId already in state $status, skip subscribe")
@@ -135,7 +135,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
             yield()
             try {
                 val status = channel.status.value
-                if (status == RealtimeChannel.Status.UNSUBSCRIBED || status == RealtimeChannel.Status.UNSUBSCRIBED) {
+                if (status == RealtimeChannel.Status.UNSUBSCRIBED) {
                     channel.subscribe()
                 }
             } catch (e: Exception) {
@@ -198,7 +198,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
             yield()
             try {
                 val status = channel.status.value
-                if (status == RealtimeChannel.Status.UNSUBSCRIBED || status == RealtimeChannel.Status.UNSUBSCRIBED) {
+                if (status == RealtimeChannel.Status.UNSUBSCRIBED) {
                     channel.subscribe()
                 }
             } catch (e: Exception) {
@@ -244,7 +244,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
             yield()
             try {
                 val status = channel.status.value
-                if (status == RealtimeChannel.Status.UNSUBSCRIBED || status == RealtimeChannel.Status.UNSUBSCRIBED) {
+                if (status == RealtimeChannel.Status.UNSUBSCRIBED) {
                     channel.subscribe()
                 }
             } catch (e: Exception) {
@@ -295,7 +295,7 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
             yield()
             try {
                 val status = channel.status.value
-                if (status == RealtimeChannel.Status.UNSUBSCRIBED || status == RealtimeChannel.Status.UNSUBSCRIBED) {
+                if (status == RealtimeChannel.Status.UNSUBSCRIBED) {
                     channel.subscribe()
                 }
             } catch (e: Exception) {


### PR DESCRIPTION
This PR addresses two critical bugs in the chat experience:

1. **Real-time Updates**: Messages were not updating instantly because the global Supabase Realtime connection was never established. I added \`it.realtime.connect()\` to the Supabase client initialization.
2. **Keyboard Behavior**: The keyboard was closing automatically after sending a message. I implemented a \`FocusRequester\` in the \`ChatInputBar\` component to explicitly maintain focus on the text input after a message is sent, ensuring the keyboard remains open for subsequent messages.

Additional cleanup:
- Fixed redundant \`RealtimeChannel.Status.UNSUBSCRIBED\` checks in \`ChatRealtimeDataSource\`.

---
*PR created automatically by Jules for task [17986177199336565952](https://jules.google.com/task/17986177199336565952) started by @TheRealAshik*