### PR TITLE
Elastic Navigation Rubber-Banding

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/core/ui/animation/ElasticOverscroll.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/core/ui/animation/ElasticOverscroll.kt
@@ -1,0 +1,115 @@
+package com.synapse.social.studioasinc.core.ui.animation
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.OverscrollEffect
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.unit.Velocity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.sign
+
+@OptIn(ExperimentalFoundationApi::class)
+class ElasticOverscrollEffect(
+    private val scope: CoroutineScope
+) : OverscrollEffect {
+    private val overscrollAnimatable = Animatable(0f)
+    private var overscrollDisplayValue by mutableFloatStateOf(0f)
+
+    override fun applyToScroll(
+        delta: Offset,
+        source: NestedScrollSource,
+        performScroll: (Offset) -> Offset
+    ): Offset {
+        val verticalDelta = delta.y
+        val currentOverscroll = overscrollDisplayValue
+
+        if (currentOverscroll != 0f && source == NestedScrollSource.UserInput) {
+            val newOverscroll = currentOverscroll + verticalDelta * 0.4f
+
+            if (sign(newOverscroll) != sign(currentOverscroll) && newOverscroll != 0f) {
+                overscrollDisplayValue = 0f
+                val usedDelta = (0f - currentOverscroll) / 0.4f
+                val remainingDelta = verticalDelta - usedDelta
+                return Offset(0f, usedDelta) + performScroll(Offset(0f, remainingDelta))
+            } else {
+                overscrollDisplayValue = newOverscroll
+                return delta
+            }
+        }
+
+        val consumed = performScroll(delta)
+        val remainder = verticalDelta - consumed.y
+
+        if (abs(remainder) > 0.5f && source == NestedScrollSource.UserInput) {
+            overscrollDisplayValue = currentOverscroll + remainder * 0.4f
+            return delta
+        }
+
+        return consumed
+    }
+
+    override suspend fun applyToFling(
+        velocity: Velocity,
+        performFling: suspend (Velocity) -> Velocity
+    ) {
+        overscrollAnimatable.snapTo(overscrollDisplayValue)
+
+        if (overscrollAnimatable.value != 0f) {
+            overscrollAnimatable.animateTo(
+                targetValue = 0f,
+                animationSpec = spring(
+                    dampingRatio = 0.4f,
+                    stiffness = Spring.StiffnessHigh
+                )
+            ) {
+                overscrollDisplayValue = value
+            }
+        } else {
+            performFling(velocity)
+        }
+    }
+
+    override val node: Modifier.Node = object : Modifier.Node() {}
+
+    // Rename to avoid conflict with supertype
+    val distortionModifier: Modifier = Modifier.graphicsLayer {
+        val overscroll = overscrollDisplayValue
+        if (overscroll == 0f) return@graphicsLayer
+
+        translationY = overscroll
+
+        val stretchFactor = (abs(overscroll) / 1000f).coerceAtMost(0.15f)
+        scaleY = 1f + stretchFactor
+        scaleX = 1f - (stretchFactor * 0.5f)
+
+        transformOrigin = if (overscroll > 0) {
+            TransformOrigin(0.5f, 0f)
+        } else {
+            TransformOrigin(0.5f, 1f)
+        }
+    }
+
+    override val isInProgress: Boolean
+        get() = overscrollDisplayValue != 0f
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun rememberElasticOverscrollEffect(): ElasticOverscrollEffect {
+    val scope = rememberCoroutineScope()
+    return remember(scope) { ElasticOverscrollEffect(scope) }
+}

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/core/ui/components/ElasticContainer.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/core/ui/components/ElasticContainer.kt
@@ -1,0 +1,28 @@
+package com.synapse.social.studioasinc.core.ui.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.overscroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.synapse.social.studioasinc.core.ui.animation.rememberElasticOverscrollEffect
+
+/**
+ * A container that applies an elastic rubber-banding effect when its content is pulled
+ * beyond its scroll boundaries.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ElasticContainer(
+    modifier: Modifier = Modifier,
+    content: @Composable (Modifier) -> Unit
+) {
+    val overscrollEffect = rememberElasticOverscrollEffect()
+
+    Box(
+        modifier = modifier
+            .overscroll(overscrollEffect)
+    ) {
+        content(overscrollEffect.distortionModifier)
+    }
+}

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/FeedScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/FeedScreen.kt
@@ -53,6 +53,7 @@ import com.synapse.social.studioasinc.feature.shared.components.post.PostSummary
 import com.synapse.social.studioasinc.ui.components.ExpressivePullToRefreshIndicator
 import com.synapse.social.studioasinc.feature.stories.tray.StoryTray
 import com.synapse.social.studioasinc.feature.stories.tray.StoryTrayViewModel
+import com.synapse.social.studioasinc.core.ui.components.ElasticContainer
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -182,10 +183,12 @@ fun FeedScreen(
                         !isRefreshing
 
         androidx.compose.runtime.CompositionLocalProvider(com.synapse.social.studioasinc.feature.shared.components.LocalLinkMetadataUseCase provides linkViewModel.getLinkMetadataUseCase) {
+            ElasticContainer(modifier = Modifier.fillMaxSize()) { elasticModifier ->
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background),
+                    .background(MaterialTheme.colorScheme.background)
+                    .then(elasticModifier),
                 contentPadding = contentPadding
             ) {
 
@@ -290,6 +293,7 @@ fun FeedScreen(
                         )
                     }
                 }
+            }
             }
         }
     }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostOptionsBottomSheet.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostOptionsBottomSheet.kt
@@ -20,6 +20,9 @@ import com.synapse.social.studioasinc.R
 import com.synapse.social.studioasinc.domain.model.Post
 import com.synapse.social.studioasinc.feature.shared.theme.Sizes
 import com.synapse.social.studioasinc.feature.shared.theme.Spacing
+import com.synapse.social.studioasinc.core.ui.components.ElasticContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.rememberScrollState
 
 data class PostOption(
     val label: String,
@@ -54,9 +57,12 @@ fun PostOptionsBottomSheet(
         onDismissRequest = onDismiss,
         containerColor = MaterialTheme.colorScheme.surface
     ) {
+        ElasticContainer(modifier = Modifier.fillMaxWidth()) { elasticModifier ->
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .then(elasticModifier)
+                .verticalScroll(rememberScrollState())
                 .padding(bottom = Spacing.Medium)
         ) {
 
@@ -122,6 +128,7 @@ fun PostOptionsBottomSheet(
                     OptionItem(option = option)
                 }
             }
+        }
         }
     }
 

--- a/check_overscroll.kt
+++ b/check_overscroll.kt
@@ -1,0 +1,7 @@
+import androidx.compose.foundation.OverscrollEffect
+import androidx.compose.ui.Modifier
+
+fun check(effect: OverscrollEffect) {
+    // try different ways to access
+    val m: Modifier = effect.modifier
+}


### PR DESCRIPTION
Implementation of tactile elastic rubber-banding for navigation boundaries in Compose. Includes a custom OverscrollEffect with spring physics and volume-preserving distortion. Applied to the main feed and bottom sheets.

Fixes #148

---
*PR created automatically by Jules for task [8531891096142129574](https://jules.google.com/task/8531891096142129574) started by @TheRealAshik*