### PR TITLE
Fix real-time DM message subscription

### DIFF
--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/ChatRealtimeDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/ChatRealtimeDataSource.kt
@@ -63,24 +63,11 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
 
         val channel = client.realtime.channel(channelId)
 
-        // Register the postgres change listener BEFORE subscribing — required by supabase-kt
         val changeFlow = channel.postgresChangeFlow<PostgresAction.Insert>(schema = "public") {
             table = "messages"
             filter("chat_id", FilterOperator.EQ, chatId)
         }
 
-        // Subscribe first (blocks until the WebSocket channel is SUBSCRIBED)
-        try {
-            channel.subscribe(blockUntilSubscribed = true)
-        } catch (e: Exception) {
-            if (e !is CancellationException) {
-                Napier.e("Failed to subscribe to messages channel", e)
-                close(e)
-                return@callbackFlow
-            }
-        }
-
-        // Now collect — channel is guaranteed to be active
         val collector = launch(AppDispatchers.IO) {
             changeFlow.collect { action ->
                 try {
@@ -91,10 +78,26 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
             }
         }
 
+        launch(AppDispatchers.IO) {
+            yield()
+            try {
+                val status = channel.status.value
+                if (status == RealtimeChannel.Status.UNSUBSCRIBED) {
+                    channel.subscribe()
+                }
+            } catch (e: Exception) {
+                if (e !is CancellationException) {
+                    Napier.e("Failed to subscribe to messages channel", e)
+                    close(e)
+                }
+            }
+        }
+
         awaitClose {
             collector.cancel()
             launch {
                 try {
+                    yield()
                     channel.unsubscribe()
                     client.realtime.removeChannel(channel)
                 } catch (e: Exception) {


### PR DESCRIPTION
In `ChatRealtimeDataSource.subscribeToMessages(chatId)`:
1. The method creates a `postgresChangeFlow` (which is a cold flow under `supabase-kt`).
2. It then immediately calls `channel.subscribe(blockUntilSubscribed = true)` synchronously.
3. Finally, it launches a coroutine to collect the `changeFlow`.

### Why This Fails

In the `supabase-kt` library, calling `channel.postgresChangeFlow(...)` returns a cold Flow. The Postgres change listener/filter is **only registered internally with the channel when the Flow begins collection** (i.e. inside `.collect { ... }`).
Because `channel.subscribe(...)` is executed *before* collection starts:
- The WebSocket client connects to the Supabase channel with **no registered Postgres filters**.
- The Supabase server subscribes the connection but does not broadcast any postgres insert events for the "messages" table to this client.
- When the flow collector starts collecting later, the client knows what to listen for, but the server is unaware because the subscription message has already been processed without the filter.

## Proposed Changes

We modified `ChatRealtimeDataSource.subscribeToMessages` to match the correct, proven asynchronous subscription pattern used by other working subscription functions in the same class (like `subscribeToInboxUpdates` and `subscribeToReadReceipts`).

- Launched the `changeFlow` collector coroutine on `AppDispatchers.IO` first. This registers the Postgres change filter on the client-side channel.
- Next, launched the subscription block in a separate coroutine on `AppDispatchers.IO`.
- Added a `yield()` inside the subscription coroutine to allow the collector coroutine to run first and complete its registration.
- Once registered, call `channel.subscribe()`.
- Cleaned up any channel leaks in `awaitClose` by adding a `yield()` and robustly unsubscribing.

---
*PR created automatically by Jules for task [3655350916083078131](https://jules.google.com/task/3655350916083078131) started by @TheRealAshik*