### PR TITLE
Fix avatar initials fallback

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/createpost/createpost/components/UserHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/createpost/createpost/components/UserHeader.kt
@@ -65,32 +65,13 @@ fun UserHeader(
             .padding(vertical = Spacing.Medium)
     ) {
 
-        if (user?.avatar != null) {
-            AsyncImage(
-                model = user.avatar,
-                contentDescription = stringResource(R.string.cd_profile_picture),
-                modifier = Modifier
-                    .size(Sizes.IconGiant)
-                    .clip(CircleShape),
-                contentScale = ContentScale.Crop,
-                placeholder = rememberVectorPainter(Icons.Filled.Person),
-                error = rememberVectorPainter(Icons.Filled.Person)
-            )
-        } else {
-            Box(
-                modifier = Modifier
-                    .size(Sizes.IconGiant)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    Icons.Default.Person,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
+        com.synapse.social.studioasinc.ui.components.CircularAvatar(
+            imageUrl = user?.avatar,
+            contentDescription = stringResource(R.string.cd_profile_picture),
+            modifier = Modifier,
+            size = Sizes.IconGiant,
+            displayName = user?.displayName ?: user?.username
+        )
 
         Spacer(modifier = Modifier.width(Spacing.SmallMedium))
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/FeedScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/FeedScreen.kt
@@ -192,7 +192,8 @@ fun FeedScreen(
                 item {
                     QuickPostArea(
                         userProfileUrl = currentUser?.avatar,
-                        onClick = onCreatePostClick
+                        onClick = onCreatePostClick,
+                        displayName = currentUser?.displayName ?: currentUser?.username
                     )
                 }
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/components/QuickPostArea.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/components/QuickPostArea.kt
@@ -28,7 +28,8 @@ import com.synapse.social.studioasinc.ui.components.CircularAvatar
 fun QuickPostArea(
     userProfileUrl: String?,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    displayName: String? = null
 ) {
     Card(
         modifier = modifier
@@ -49,7 +50,8 @@ fun QuickPostArea(
                 CircularAvatar(
                     imageUrl = userProfileUrl,
                     contentDescription = stringResource(R.string.profile),
-                    size = Sizes.AvatarMedium
+                    size = Sizes.AvatarMedium,
+                    displayName = displayName
                 )
 
                 Spacer(modifier = Modifier.width(Spacing.Small))

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatTopAppBar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatTopAppBar.kt
@@ -85,7 +85,8 @@ fun ChatTopAppBar(
                         userId = participantId ?: "",
                         avatarUrl = participantProfile?.avatar ?: initialParticipantAvatar,
                         size = Sizes.IconMassive,
-                        showActiveStatus = true
+                        showActiveStatus = true,
+                        displayName = participantProfile?.displayName ?: participantProfile?.username ?: initialParticipantName
                     )
                     Spacer(modifier = Modifier.width(Spacing.SmallMedium))
                     Column {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageBubble.kt
@@ -662,7 +662,7 @@ fun MessageBubble(
             && message.deliveryStatus == DeliveryStatus.READ) {
             com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
                 avatarUrl = senderAvatarUrl,
-                displayName = null,
+                displayName = senderName,
                 size = Sizes.AvatarTiny,
                 modifier = Modifier.padding(top = Spacing.Tiny)
             )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/UserAvatarWithStatus.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/UserAvatarWithStatus.kt
@@ -19,6 +19,7 @@ fun UserAvatarWithStatus(
     size: Dp = 40.dp,
     showActiveStatus: Boolean = true,
     modifier: Modifier = Modifier,
+    displayName: String? = null,
     viewModel: UserPresenceViewModel = hiltViewModel()
 ) {
     val isActive by viewModel.observeUserStatus(userId).collectAsState(initial = false)
@@ -28,6 +29,7 @@ fun UserAvatarWithStatus(
         UserAvatar(
             avatarUrl = avatarUrl,
             size = size,
+            displayName = displayName,
             modifier = Modifier.align(Alignment.Center)
         )
         

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/UserListItem.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/UserListItem.kt
@@ -31,7 +31,8 @@ fun UserListItem(
             userId = user.uid,
             avatarUrl = user.avatar,
             size = Sizes.AvatarDefault,
-            showActiveStatus = true
+            showActiveStatus = true,
+            displayName = user.displayName ?: user.username
         )
         
         Spacer(modifier = Modifier.width(Spacing.SmallMedium))

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/picker/FileListContent.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/picker/FileListContent.kt
@@ -177,7 +177,8 @@ private fun ContactListItem(
     ) {
         UserAvatar(
             avatarUrl = null, // Contacts don't have avatar URLs in this implementation yet, using default
-            size = Sizes.AvatarMedium
+            size = Sizes.AvatarMedium,
+            displayName = file.fileName
         )
 
         Spacer(modifier = Modifier.width(Spacing.Medium))

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCard.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCard.kt
@@ -176,7 +176,8 @@ fun PostCard(
                     imageUrl = state.user.avatar,
                     contentDescription = "Avatar of ${state.user.username}",
                     onClick = onUserClick,
-                    size = avatarSize
+                    size = avatarSize,
+                    displayName = state.user.displayName ?: state.user.username
                 )
             }
 


### PR DESCRIPTION
Updated various avatar components and their call sites to ensure the user's display name or username is passed. This allows the avatar to correctly display the first letter of the name as a fallback when the image URL is null or empty, instead of showing a "?" placeholder. Screens updated include Feed, Create Post, Chat, and various user lists.

---
*PR created automatically by Jules for task [5277763879682706757](https://jules.google.com/task/5277763879682706757) started by @TheRealAshik*