### PR TITLE
✨ feat: Add Lock Profile screen

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/DomainProfileRepositoryAdapter.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/DomainProfileRepositoryAdapter.kt
@@ -90,7 +90,8 @@ private fun com.synapse.social.studioasinc.data.model.UserProfile.toDomain(): Do
         personalWebsite = personalWebsite,
         publicEmail = publicEmail,
         pronouns = pronouns,
-        gender = gender?.let { runCatching { Gender.valueOf(it.uppercase()) }.getOrNull() }
+        gender = gender?.let { runCatching { Gender.valueOf(it.uppercase()) }.getOrNull() },
+        isPrivate = isPrivate
     )
 
 internal fun DomainUserProfile.toData(): com.synapse.social.studioasinc.data.model.UserProfile =
@@ -117,5 +118,6 @@ internal fun DomainUserProfile.toData(): com.synapse.social.studioasinc.data.mod
         personalWebsite = personalWebsite,
         publicEmail = publicEmail,
         pronouns = pronouns,
-        gender = gender?.name?.lowercase()
+        gender = gender?.name?.lowercase(),
+        isPrivate = isPrivate
     )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/ProfileActionRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/ProfileActionRepositoryImpl.kt
@@ -10,7 +10,7 @@ class ProfileActionRepositoryImpl {
 
     suspend fun lockProfile(userId: String, isLocked: Boolean): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            supabase.from("profiles")
+            supabase.from("users")
                 .update(mapOf("is_private" to isLocked)) {
                     filter { eq("id", userId) }
                 }
@@ -22,7 +22,7 @@ class ProfileActionRepositoryImpl {
 
     suspend fun archiveProfile(userId: String, isArchived: Boolean): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            supabase.from("profiles")
+            supabase.from("users")
                 .update(mapOf("is_archived" to isArchived)) {
                     filter { eq("id", userId) }
                 }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/UserProfile.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/UserProfile.kt
@@ -61,6 +61,7 @@ data class UserProfile(
     @SerialName("public_email") val publicEmail: String? = null,
     @SerialName("public_phone") val publicPhone: String? = null,
     @SerialName("preferred_communication") val preferredCommunication: String? = null,
+    @SerialName("is_private") val isPrivate: Boolean = false,
 
     @SerialName("created_at") val createdAt: String? = null,
     @SerialName("updated_at") val updatedAt: String? = null

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/lockprofile/LockProfileScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/lockprofile/LockProfileScreen.kt
@@ -1,0 +1,138 @@
+package com.synapse.social.studioasinc.feature.profile.lockprofile
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.synapse.social.studioasinc.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LockProfileScreen(
+    viewModel: LockProfileViewModel,
+    onNavigateBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uiState.isSaved) {
+        if (uiState.isSaved) {
+            onNavigateBack()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.lock_profile_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(48.dp))
+
+            val lockIcon: ImageVector = if (uiState.isPrivate) {
+                Icons.Filled.Lock
+            } else {
+                Icons.Outlined.Lock
+            }
+
+            Icon(
+                imageVector = lockIcon,
+                contentDescription = null,
+                modifier = Modifier.size(120.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = if (uiState.isPrivate) {
+                    stringResource(R.string.profile_is_locked)
+                } else {
+                    stringResource(R.string.lock_your_profile)
+                },
+                style = MaterialTheme.typography.headlineSmall,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = stringResource(R.string.lock_profile_description),
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = stringResource(R.string.lock_profile_toggle_label),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Switch(
+                    checked = uiState.isPrivate,
+                    onCheckedChange = { viewModel.toggleLock(it) }
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Button(
+                onClick = { viewModel.save() },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !uiState.isLoading
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text(stringResource(R.string.save))
+                }
+            }
+
+            uiState.error?.let { error ->
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = error,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/lockprofile/LockProfileScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/lockprofile/LockProfileScreen.kt
@@ -1,6 +1,9 @@
 package com.synapse.social.studioasinc.feature.profile.lockprofile
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Lock
@@ -12,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -25,9 +29,16 @@ fun LockProfileScreen(
     onNavigateBack: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
 
     LaunchedEffect(uiState.isSaved) {
         if (uiState.isSaved) {
+            val message = if (uiState.isPrivate) {
+                context.getString(R.string.profile_locked_successfully)
+            } else {
+                context.getString(R.string.profile_unlocked_successfully)
+            }
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
             onNavigateBack()
         }
     }
@@ -51,63 +62,70 @@ fun LockProfileScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .padding(24.dp)
         ) {
-            Spacer(modifier = Modifier.height(48.dp))
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(modifier = Modifier.height(48.dp))
 
-            val lockIcon: ImageVector = if (uiState.isPrivate) {
-                Icons.Filled.Lock
-            } else {
-                Icons.Outlined.Lock
-            }
-
-            Icon(
-                imageVector = lockIcon,
-                contentDescription = null,
-                modifier = Modifier.size(120.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Text(
-                text = if (uiState.isPrivate) {
-                    stringResource(R.string.profile_is_locked)
+                val lockIcon: ImageVector = if (uiState.isPrivate) {
+                    Icons.Filled.Lock
                 } else {
-                    stringResource(R.string.lock_your_profile)
-                },
-                style = MaterialTheme.typography.headlineSmall,
-                textAlign = TextAlign.Center
-            )
+                    Icons.Outlined.Lock
+                }
+
+                Icon(
+                    imageVector = lockIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(120.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = if (uiState.isPrivate) {
+                        stringResource(R.string.profile_is_locked)
+                    } else {
+                        stringResource(R.string.lock_your_profile)
+                    },
+                    style = MaterialTheme.typography.headlineSmall,
+                    textAlign = TextAlign.Center
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(R.string.lock_profile_description),
+                    style = MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(48.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = stringResource(R.string.lock_profile_toggle_label),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Switch(
+                        checked = uiState.isPrivate,
+                        onCheckedChange = { viewModel.toggleLock(it) }
+                    )
+                }
+            }
 
             Spacer(modifier = Modifier.height(16.dp))
-
-            Text(
-                text = stringResource(R.string.lock_profile_description),
-                style = MaterialTheme.typography.bodyLarge,
-                textAlign = TextAlign.Center,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            Spacer(modifier = Modifier.height(48.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text = stringResource(R.string.lock_profile_toggle_label),
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Switch(
-                    checked = uiState.isPrivate,
-                    onCheckedChange = { viewModel.toggleLock(it) }
-                )
-            }
-
-            Spacer(modifier = Modifier.weight(1f))
 
             Button(
                 onClick = { viewModel.save() },
@@ -130,7 +148,9 @@ fun LockProfileScreen(
                 Text(
                     text = error,
                     color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodyMedium
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
                 )
             }
         }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/lockprofile/LockProfileScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/lockprofile/LockProfileScreen.kt
@@ -18,9 +18,10 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.synapse.social.studioasinc.R
+import com.synapse.social.studioasinc.feature.shared.theme.Sizes
+import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -62,7 +63,7 @@ fun LockProfileScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(24.dp)
+                .padding(Spacing.Large)
         ) {
             Column(
                 modifier = Modifier
@@ -71,7 +72,7 @@ fun LockProfileScreen(
                     .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Spacer(modifier = Modifier.height(48.dp))
+                Spacer(modifier = Modifier.height(Spacing.Huge))
 
                 val lockIcon: ImageVector = if (uiState.isPrivate) {
                     Icons.Filled.Lock
@@ -82,11 +83,11 @@ fun LockProfileScreen(
                 Icon(
                     imageVector = lockIcon,
                     contentDescription = null,
-                    modifier = Modifier.size(120.dp),
+                    modifier = Modifier.size(Sizes.AvatarLargeProfile),
                     tint = MaterialTheme.colorScheme.primary
                 )
 
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(Spacing.Large))
 
                 Text(
                     text = if (uiState.isPrivate) {
@@ -98,7 +99,7 @@ fun LockProfileScreen(
                     textAlign = TextAlign.Center
                 )
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(Spacing.Medium))
 
                 Text(
                     text = stringResource(R.string.lock_profile_description),
@@ -107,7 +108,7 @@ fun LockProfileScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
 
-                Spacer(modifier = Modifier.height(48.dp))
+                Spacer(modifier = Modifier.height(Spacing.Huge))
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -125,7 +126,7 @@ fun LockProfileScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(Spacing.Medium))
 
             Button(
                 onClick = { viewModel.save() },
@@ -134,9 +135,9 @@ fun LockProfileScreen(
             ) {
                 if (uiState.isLoading) {
                     CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
+                        modifier = Modifier.size(Sizes.IconLarge),
                         color = MaterialTheme.colorScheme.onPrimary,
-                        strokeWidth = 2.dp
+                        strokeWidth = Sizes.BorderDefault
                     )
                 } else {
                     Text(stringResource(R.string.save))
@@ -144,7 +145,7 @@ fun LockProfileScreen(
             }
 
             uiState.error?.let { error ->
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(Spacing.Medium))
                 Text(
                     text = error,
                     color = MaterialTheme.colorScheme.error,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/lockprofile/LockProfileViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/lockprofile/LockProfileViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -43,7 +44,7 @@ class LockProfileViewModel @Inject constructor(
             currentUserId = userId
 
             if (userId != null) {
-                getProfileUseCase(userId).collect { result ->
+                getProfileUseCase(userId).take(1).collect { result ->
                     result.onSuccess { profile ->
                         _uiState.update { it.copy(isPrivate = profile.isPrivate, isLoading = false) }
                     }.onFailure { error ->
@@ -61,7 +62,11 @@ class LockProfileViewModel @Inject constructor(
     }
 
     fun save() {
-        val userId = currentUserId ?: return
+        val userId = currentUserId
+        if (userId == null) {
+            _uiState.update { it.copy(error = "User not logged in") }
+            return
+        }
         val isLocked = _uiState.value.isPrivate
 
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/lockprofile/LockProfileViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/lockprofile/LockProfileViewModel.kt
@@ -1,0 +1,78 @@
+package com.synapse.social.studioasinc.feature.profile.lockprofile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.synapse.social.studioasinc.domain.usecase.profile.GetProfileUseCase
+import com.synapse.social.studioasinc.domain.usecase.profile.LockProfileUseCase
+import com.synapse.social.studioasinc.shared.domain.usecase.auth.GetCurrentUserIdUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class LockProfileUiState(
+    val isPrivate: Boolean = false,
+    val isLoading: Boolean = false,
+    val isSaved: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class LockProfileViewModel @Inject constructor(
+    private val lockProfileUseCase: LockProfileUseCase,
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
+    private val getProfileUseCase: GetProfileUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(LockProfileUiState())
+    val uiState: StateFlow<LockProfileUiState> = _uiState.asStateFlow()
+
+    private var currentUserId: String? = null
+
+    init {
+        loadCurrentProfile()
+    }
+
+    private fun loadCurrentProfile() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val userId = getCurrentUserIdUseCase()
+            currentUserId = userId
+
+            if (userId != null) {
+                getProfileUseCase(userId).collect { result ->
+                    result.onSuccess { profile ->
+                        _uiState.update { it.copy(isPrivate = profile.isPrivate, isLoading = false) }
+                    }.onFailure { error ->
+                        _uiState.update { it.copy(error = error.message, isLoading = false) }
+                    }
+                }
+            } else {
+                _uiState.update { it.copy(error = "User not logged in", isLoading = false) }
+            }
+        }
+    }
+
+    fun toggleLock(isLocked: Boolean) {
+        _uiState.update { it.copy(isPrivate = isLocked) }
+    }
+
+    fun save() {
+        val userId = currentUserId ?: return
+        val isLocked = _uiState.value.isPrivate
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            lockProfileUseCase(userId, isLocked).collect { result ->
+                result.onSuccess {
+                    _uiState.update { it.copy(isLoading = false, isSaved = true) }
+                }.onFailure { error ->
+                    _uiState.update { it.copy(isLoading = false, error = error.message) }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileDialogs.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileDialogs.kt
@@ -29,7 +29,7 @@ internal fun ProfileMoreMenuSection(
             onShareProfile = { viewModel.showShareSheet() },
             onViewAs = { viewModel.showViewAsSheet() },
             onLockProfile = {
-                profile?.let { viewModel.lockProfile(!it.isPrivate) }
+                viewModel.showLockProfileScreen()
             },
             onQrCode = { viewModel.showQrCode() },
             onSettings = onNavigateToSettings,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileScreen.kt
@@ -65,6 +65,7 @@ fun ProfileScreen(
     onNavigateToChat: (String, String?, String?) -> Unit = { _, _, _ -> },
     onNavigateToStoryCreator: () -> Unit = {},
     onNavigateToQuotePost: (String) -> Unit = {},
+    onNavigateToLockProfile: () -> Unit = {},
     viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -121,6 +122,13 @@ fun ProfileScreen(
 
     LaunchedEffect(userId) {
         viewModel.loadProfile(userId)
+    }
+
+    LaunchedEffect(state.navigateToLockProfile) {
+        if (state.navigateToLockProfile) {
+            onNavigateToLockProfile()
+            viewModel.hideLockProfileScreen()
+        }
     }
 
     Scaffold(

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileViewModel.kt
@@ -85,7 +85,8 @@ data class ProfileScreenState(
     val blockError: String? = null,
     val isSummarizing: Boolean = false,
     val postSummary: String? = null,
-    val summaryError: String? = null
+    val summaryError: String? = null,
+    val navigateToLockProfile: Boolean = false
 )
 
 @HiltViewModel
@@ -357,6 +358,14 @@ class ProfileViewModel @Inject constructor(
 
     fun toggleMoreMenu() {
         _state.update { it.copy(showMoreMenu = !it.showMoreMenu) }
+    }
+
+    fun showLockProfileScreen() {
+        _state.update { it.copy(navigateToLockProfile = true, showMoreMenu = false) }
+    }
+
+    fun hideLockProfileScreen() {
+        _state.update { it.copy(navigateToLockProfile = false) }
     }
 
     fun switchContentFilter(filter: ProfileContentFilter) {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/navigation/AppDestination.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/navigation/AppDestination.kt
@@ -41,6 +41,8 @@ sealed interface AppDestination {
     @Serializable
     data object ChatPrivacy : AppDestination
     @Serializable
+    data object LockProfile : AppDestination
+    @Serializable
     data object CreateGroup : AppDestination
     @Serializable
     data class GroupInfo(val chatId: String, val groupName: String) : AppDestination

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/navigation/AppNavigation.kt
@@ -45,6 +45,8 @@ import com.synapse.social.studioasinc.feature.stories.viewer.StoryViewerViewMode
 import com.synapse.social.studioasinc.feature.stories.creator.StoryCreatorActivity
 import com.synapse.social.studioasinc.feature.shared.reels.ReelUploadManager
 import com.synapse.social.studioasinc.feature.profile.profile.ProfileViewModel
+import com.synapse.social.studioasinc.feature.profile.lockprofile.LockProfileScreen
+import com.synapse.social.studioasinc.feature.profile.lockprofile.LockProfileViewModel
 import com.synapse.social.studioasinc.ui.settings.SettingsNavHost
 import kotlinx.serialization.Serializable
 import com.synapse.social.studioasinc.feature.inbox.inbox.screens.ChatScreen
@@ -256,10 +258,20 @@ fun NavGraphBuilder.profileGraph(
                     onNavigateToStoryCreator = {
                         context.startActivity(Intent(context, StoryCreatorActivity::class.java))
                     },
+                    onNavigateToLockProfile = {
+                        navController.navigate(AppDestination.LockProfile)
+                    },
                     viewModel = viewModel
                 )
             }
-    composable<AppDestination.EditProfile> {
+            composable<AppDestination.LockProfile> {
+                val viewModel: LockProfileViewModel = hiltViewModel()
+                LockProfileScreen(
+                    viewModel = viewModel,
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+            composable<AppDestination.EditProfile> {
                 val viewModel: EditProfileViewModel = hiltViewModel()
 
                 val savedStateHandle = navController.currentBackStackEntry?.savedStateHandle

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1405,6 +1405,15 @@ Please explain the following message from %3$s in detail, considering the contex
     <string name="see_as_specific_person">See as a specific person</string>
     <string name="view_as_title">View As</string>
 
+    <!-- Lock Profile Screen -->
+    <string name="lock_profile_title">Lock Profile</string>
+    <string name="lock_your_profile">Lock Your Profile</string>
+    <string name="profile_is_locked">Profile is Locked</string>
+    <string name="lock_profile_description">When your profile is locked, only your followers can see your posts, stories, and profile details. New followers need your approval.</string>
+    <string name="lock_profile_toggle_label">Lock Profile</string>
+    <string name="profile_locked_successfully">Profile locked successfully</string>
+    <string name="profile_unlocked_successfully">Profile unlocked successfully</string>
+
 
     <!-- File Picker -->
     <string name="picker_category_media">Media</string>


### PR DESCRIPTION
This PR implements the "Lock Profile" feature end-to-end. 

Key changes:
- **Data Layer**: Fixed `ProfileActionRepositoryImpl` to target the `users` table. Updated `UserProfile` DTO and its mapper to include the `is_private` field.
- **Domain Layer**: Updated `UserProfile` domain model to include `isPrivate`.
- **Presentation Layer**: 
    - Created `LockProfileScreen` and `LockProfileViewModel`.
    - Added `LockProfile` to `AppDestination` and registered it in `AppNavigation`.
    - Updated `ProfileViewModel` and `ProfileScreen` to handle navigation to the new screen.
    - Updated `ProfileMoreMenuSection` in `ProfileDialogs.kt` to trigger navigation.
- **Resources**: Added strings for the new screen in `strings.xml`.

Verified the build with `./gradlew :app:compileDebugKotlin` and addressed code review feedback regarding model mapping and UI code quality.

---
*PR created automatically by Jules for task [10693030928002109114](https://jules.google.com/task/10693030928002109114) started by @TheRealAshik*