### PR TITLE
develop -> main

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
@@ -90,14 +90,11 @@ class FeedPagingSource(
             }
 
             val timelineResponse: List<JsonObject> = rpcResult
-                .distinctBy { it["post_id"]?.jsonPrimitive?.contentOrNull }
-                .map { item ->
-                    // Convert RPC result to match the expected timeline structure for the rest of the method
-                    buildJsonObject {
-                        put("id", item["post_id"] ?: JsonNull)
-                        put("post_id", item["post_id"] ?: JsonNull)
-                        put("item_type", "post")
-                    }
+                .distinctBy {
+                    // Reshares must use their own id (not post_id) to allow the same post reshared by different users
+                    val type = it["item_type"]?.jsonPrimitive?.contentOrNull
+                    if (type == "reshare") "reshare:${it["id"]?.jsonPrimitive?.contentOrNull}"
+                    else it["post_id"]?.jsonPrimitive?.contentOrNull
                 }
 
             Log.d("FeedPagingSource", "Loaded ${timelineResponse.size} feed items")

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/ProfilePostsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/ProfilePostsRepositoryImpl.kt
@@ -82,6 +82,16 @@ internal class ProfilePostsRepositoryImpl(
             row["post_id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it.contentOrNull else null }
         }
 
+        // Build a map of post_id -> reshare created_at epoch millis for sort ordering
+        val reshareTimestampMap = reshareRows.associate { row ->
+            val postId = row["post_id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it.contentOrNull else null } ?: ""
+            val createdAt = row["created_at"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it.contentOrNull else null }
+            val epochMs = createdAt?.let {
+                runCatching { java.time.Instant.parse(it).toEpochMilli() }.getOrNull()
+            }
+            postId to epochMs
+        }
+
         val resharedPosts = if (resharedPostIds.isNotEmpty()) {
             // Fetch resharer's username once
             val resharerUsername = client.from("users").select(
@@ -96,11 +106,14 @@ internal class ProfilePostsRepositoryImpl(
             ) {
                 filter { isIn(KEY_ID, resharedPostIds) }
             }.decodeList<JsonObject>().mapNotNull { data ->
-                parsePost(data)?.copy(resharedByUsername = resharerUsername, isReshared = true)
+                val post = parsePost(data) ?: return@mapNotNull null
+                // Use reshare created_at as the sort timestamp so reshares surface at reshare time
+                val sortTimestamp = reshareTimestampMap[post.id] ?: post.timestamp
+                post.copy(resharedByUsername = resharerUsername, isReshared = true, timestamp = sortTimestamp)
             }
         } else emptyList()
 
-        // Merge own posts + reshares, sorted by timestamp descending
+        // Merge own posts + reshares, sorted by reshare/post time descending
         val merged = (ownPosts + resharedPosts).sortedByDescending { it.timestamp }
 
         val enrichedPosts = populatePostReactions(merged)

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatInputBar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatInputBar.kt
@@ -406,7 +406,7 @@ fun ChatInputBar(
                     ),
                     cursorBrush = SolidColor(Color(0xFF4CAF50)),
                     decorationBox = { innerTextField ->
-                        Box {
+                        Box(contentAlignment = Alignment.CenterStart) {
                             if (inputText.isEmpty()) {
                                 Text(
                                     text = stringResource(R.string.chat_type_message),

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailScreen.kt
@@ -476,6 +476,7 @@ private fun PostDetailBottomBar(
             onSend = onSendComment,
             initialValue = uiState.editingComment?.content ?: "",
             userAvatarUrl = uiState.currentUserAvatarUrl,
+            userDisplayName = uiState.currentUserDisplayName,
             replyToParticipants = uiState.replyToParticipants.map { it.username },
             onReplyingToClick = if (uiState.replyToParticipants.isNotEmpty()) onReplyingToClick else null,
             focusRequester = focusRequester

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailUiState.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailUiState.kt
@@ -18,6 +18,7 @@ data class PostDetailUiState(
     val currentUserId: String? = null,
     val commentActionsLoading: Set<String> = emptySet(),
     val currentUserAvatarUrl: String? = null,
+    val currentUserDisplayName: String? = null,
     val refreshTrigger: Int = 0,
     val blockSuccess: Boolean = false,
     val blockError: String? = null,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailViewModel.kt
@@ -76,7 +76,10 @@ class PostDetailViewModel @Inject constructor(
             
             currentUserId?.let { uid ->
                 userRepository.getUserById(uid).onSuccess { user ->
-                    _uiState.update { it.copy(currentUserAvatarUrl = user?.avatar) }
+                    _uiState.update { it.copy(
+                        currentUserAvatarUrl = user?.avatar,
+                        currentUserDisplayName = user?.displayName ?: user?.username
+                    ) }
                 }
             }
         }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/components/CommentInput.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/components/CommentInput.kt
@@ -35,6 +35,7 @@ fun CommentInput(
     modifier: Modifier = Modifier,
     initialValue: String = "",
     userAvatarUrl: String? = null,
+    userDisplayName: String? = null,
     replyToParticipants: List<String> = emptyList(),
     onReplyingToClick: (() -> Unit)? = null,
     focusRequester: FocusRequester = remember { FocusRequester() }
@@ -73,6 +74,7 @@ fun CommentInput(
             com.synapse.social.studioasinc.ui.components.CircularAvatar(
                 imageUrl = userAvatarUrl,
                 contentDescription = "My Avatar",
+                displayName = userDisplayName,
                 size = Sizes.AvatarSmall
             )
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileContentSection.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileContentSection.kt
@@ -263,17 +263,6 @@ internal fun ProfileContent(
                             )
 
                             Spacer(modifier = Modifier.height(Spacing.Medium))
-
-                            FollowingSection(
-                                users = state.followingList,
-                                selectedFilter = FollowingFilter.ALL,
-                                onFilterSelected = { },
-                                onUserClick = { user -> onNavigateToUserProfile(user.id) },
-                                onSeeAllClick = onNavigateToFollowing,
-                                modifier = Modifier.padding(horizontal = Spacing.Medium)
-                            )
-
-                            Spacer(modifier = Modifier.height(Spacing.Medium))
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/components/CoverPhoto.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/components/CoverPhoto.kt
@@ -130,6 +130,7 @@ fun CoverPhotoWithProfile(
     scrollOffset: Float = 0f,
     isOwnProfile: Boolean = false,
     hasStory: Boolean = false,
+    displayName: String? = null,
     onProfileImageClick: () -> Unit = {},
     onCoverClick: () -> Unit = {},
     coverHeight: Dp = Sizes.HeightExtraLarge,
@@ -161,6 +162,7 @@ fun CoverPhotoWithProfile(
                 status = status,
                 hasStory = hasStory,
                 isOwnProfile = isOwnProfile,
+                displayName = displayName,
                 onClick = onProfileImageClick
             )
         }
@@ -176,6 +178,7 @@ fun ProfileImageWithRing(
     status: UserStatus? = null,
     hasStory: Boolean = false,
     isOwnProfile: Boolean = false,
+    displayName: String? = null,
     onClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
@@ -259,7 +262,7 @@ fun ProfileImageWithRing(
         ) {
             com.synapse.social.studioasinc.feature.shared.components.UserAvatar(
                 avatarUrl = avatar,
-                displayName = null,
+                displayName = displayName,
                 size = size,
                 modifier = Modifier.fillMaxSize()
             )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/components/ProfileHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/components/ProfileHeader.kt
@@ -188,6 +188,7 @@ fun ProfileHeader(
                 status = status,
                 hasStory = hasStory,
                 isOwnProfile = isOwnProfile,
+                displayName = name ?: username,
                 onClick = onProfileImageClick,
                 modifier = Modifier.border(avatarBorderWidth, MaterialTheme.colorScheme.surface, CircleShape)
             )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/components/UserDetailsSection.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/components/UserDetailsSection.kt
@@ -74,6 +74,8 @@ fun UserDetailsSection(
         details.githubProfile, details.personalWebsite, details.publicEmail
     ).any { it.isNotBlank() } || details.linkedAccounts.isNotEmpty()
 
+    if (!hasDetails) return
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -143,10 +145,7 @@ fun UserDetailsSection(
                 }
             }
 
-            if (!hasDetails && isOwnProfile) {
-                Spacer(modifier = Modifier.height(Spacing.Small))
-                EmptyDetailsState(onAddClick = onCustomizeClick)
-            }
+
         }
     }
 }
@@ -452,33 +451,6 @@ private fun getPlatformIcon(platform: String): ImageVector {
         "github" -> Icons.Default.Code
         "youtube" -> Icons.Default.PlayCircle
         else -> Icons.Default.Link
-    }
-}
-
-@Composable
-private fun EmptyDetailsState(onAddClick: () -> Unit) {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = stringResource(R.string.share_more_about_yourself),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.height(Spacing.Small))
-        TextButton(
-            onClick = onAddClick,
-            modifier = Modifier.minimumInteractiveComponentSize()
-        ) {
-            Icon(
-                imageVector = Icons.Default.Add,
-                contentDescription = null,
-                modifier = Modifier.size(Sizes.IconMedium)
-            )
-            Spacer(modifier = Modifier.width(Spacing.ExtraSmall))
-            Text(stringResource(R.string.add_details))
-        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Build configuration
-projectVersion=0.5.2
+projectVersion=0.5.3
 android.suppressUnsupportedCompileSdk=36
 android.enableR8.fullMode=false
 android.enableJetifier=true

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/ChatRealtimeDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/datasource/ChatRealtimeDataSource.kt
@@ -343,9 +343,10 @@ internal class ChatRealtimeDataSource(private val client: SupabaseClientLib) {
         } catch (e: Exception) {}
 
         val channel = client.realtime.channel(channelId)
+        // message_reactions has no chat_id column — subscribe to all changes and rely on RLS
+        // to scope events to the authenticated user's accessible messages.
         val flow = channel.postgresChangeFlow<PostgresAction>(schema = "public") {
             table = "message_reactions"
-            filter("chat_id", FilterOperator.EQ, chatId)
         }
 
         val subscriptionReady = CompletableDeferred<Unit>()

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/chat/SendMessageUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/chat/SendMessageUseCase.kt
@@ -1,13 +1,13 @@
 package com.synapse.social.studioasinc.shared.domain.usecase.chat
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 
 import com.synapse.social.studioasinc.shared.domain.model.chat.Message
 import com.synapse.social.studioasinc.shared.domain.repository.ChatRepository
 import com.synapse.social.studioasinc.shared.data.crypto.SignalProtocolManager
 import com.synapse.social.studioasinc.shared.data.crypto.models.EncryptedMessage
 import io.github.aakira.napier.Napier
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -48,7 +48,8 @@ class SendMessageUseCase(
             ?: return Result.failure(Exception("Not logged in"))
 
         if (signalProtocolManager == null) {
-            return Result.failure(Exception("E2EE not initialized - SignalProtocolManager is null"))
+            Napier.e("E2EE_ENCRYPT: SignalProtocolManager is null — E2EE not initialized", tag = "E2EE")
+            return Result.failure(Exception("E2EE not initialized. Cannot send message."))
         }
 
         return try {
@@ -71,19 +72,30 @@ class SendMessageUseCase(
             }.toString()
             val contentBytes = jsonPayload.encodeToByteArray()
 
-            // Encrypt the message independently for each participant to support Double Ratchet E2EE
-            val payloadMap = coroutineScope {
+            // Encrypt concurrently for all recipients. Capture per-recipient failures without
+            // cancelling the whole coroutineScope — null signals a failed encryption for that user.
+            val payloadMap: Map<String, JsonElement> = coroutineScope {
                 otherParticipants.map { userId ->
                     async {
-                        Napier.d("E2EE_ENCRYPT: Establishing session with $userId", tag = "E2EE")
-                        // Ensure a cryptographic session exists with the recipient before encryption
-                        repository.ensureSession(userId)
-                        val encrypted = signalProtocolManager.encryptMessage(userId, contentBytes)
-                        userId to Json.encodeToJsonElement(EncryptedMessage.serializer(), encrypted)
+                        try {
+                            Napier.d("E2EE_ENCRYPT: Establishing session with $userId", tag = "E2EE")
+                            repository.ensureSession(userId)
+                            val encrypted = signalProtocolManager.encryptMessage(userId, contentBytes)
+                            userId to Json.encodeToJsonElement(EncryptedMessage.serializer(), encrypted)
+                        } catch (e: Exception) {
+                            Napier.w("E2EE_ENCRYPT: Failed to encrypt for $userId: ${e.message}", tag = "E2EE")
+                            null
+                        }
                     }
-                }.awaitAll().toMap()
+                }.awaitAll().filterNotNull().toMap()
             }
 
+            // Refuse to send if any recipient's encryption failed — avoids partial-plaintext leaks.
+            if (payloadMap.size < otherParticipants.size) {
+                return Result.failure(
+                    Exception("Encryption failed for one or more recipients. Message not sent.")
+                )
+            }
 
             val encryptedPayload = JsonObject(payloadMap).toString()
             Napier.d("E2EE_ENCRYPT: Message encrypted for ${payloadMap.size} recipients", tag = "E2EE")
@@ -99,7 +111,7 @@ class SendMessageUseCase(
             )
         } catch (e: Exception) {
             Napier.e("E2EE_ENCRYPT: Failed: ${e.message}", tag = "E2EE", throwable = e)
-            Result.failure(Exception("Encryption Error: ${e.message}"))
+            Result.failure(Exception("Encryption Error: ${e.message ?: "Unknown error"}"))
         }
     }
 }


### PR DESCRIPTION
🐞 fix(chat): remove invalid realtime filter and add E2EE plaintext fallback (#221)

* fix(chat): remove invalid chat_id realtime filter and add E2EE plaintext fallback

- ChatRealtimeDataSource: subscribeToMessageReactions was filtering on
  chat_id which does not exist in the message_reactions table, causing
  Supabase Realtime to reject the channel subscription with
  'ERROR P0001 invalid column for filter chat_id'. This destabilised the
  entire WebSocket connection and caused heartbeat timeouts, preventing
  all real-time message delivery. Fix: drop the filter and rely on RLS.

- SendMessageUseCase: when ensureSession() throws because the recipient
  has no E2EE keys uploaded, the catch block was wrapping the exception
  as 'Encryption Error: ${e.message}' — which produced the 'Encryption
  Error: Null' toast when e.message was null. Fix: per-recipient try/catch
  that falls back to plaintext send on E2EE key absence. Also falls back
  to plaintext when SignalProtocolManager is null instead of hard-failing.

Fixes #163

* fix(chat): address review — restore parallel async, remove silent plaintext fallback

- Restore coroutineScope/async/awaitAll for concurrent session setup per
  recipient (fixes O(N) sequential bottleneck flagged in review).
- Remove silent plaintext fallbacks (signalProtocolManager null and
  per-recipient key absence). Both cases now return Result.failure with
  a clear message so the UI can surface the error explicitly rather than
  silently downgrading to unencrypted transmission.
- Per-recipient encryption failures are captured inside the async block
  (null) and the use case fails hard if any recipient's encryption could
  not complete, preventing partial-plaintext message leaks.

* fix: align placeholder text vertically in ChatInputBar

* chore: bump version to 0.5.3