### PR TITLE
✨ feat: X-style replying-to, comment view tracking, and feed fixes

### DIFF
--- a/.jules/inlined-docs.md
+++ b/.jules/inlined-docs.md
@@ -7,3 +7,4 @@
 6. shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/OfflineActionRepositoryImpl.kt
 7. shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/ChatEncryptionHelper.kt
 8. shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/domain/usecase/chat/SendMessageUseCase.kt
+9. shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseCommentRepository.kt

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
@@ -166,11 +166,11 @@ class FeedPagingSource(
                 val parentCommentId = timelineItem["parent_comment_id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
                 val parentAuthorUsername = timelineItem["parent_author_username"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
                 val replyToUsernames = timelineItem["reply_to_usernames"]?.jsonArray
-                    ?.mapNotNull { (it as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull }
+                    ?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
                     ?: listOfNotNull(parentAuthorUsername)
-                val createdAt = timelineItem["created_at"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
-                val timestamp = timelineItem["timestamp"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.longOrNull ?: 0L
-                val likeCount = timelineItem["likes_count"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.intOrNull ?: 0
+                val createdAt = timelineItem["created_at"]?.let { if (it is JsonPrimitive) it else null }?.contentOrNull
+                val timestamp = timelineItem["timestamp"]?.let { if (it is JsonPrimitive) it else null }?.longOrNull ?: 0L
+                val likeCount = timelineItem["likes_count"]?.let { if (it is JsonPrimitive) it else null }?.intOrNull ?: 0
                 val commentCount = timelineItem["comments_count"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.intOrNull ?: 0
                 
                 // We need to fetch the author details for comments.

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
@@ -165,6 +165,9 @@ class FeedPagingSource(
                 val parentPostId = timelineItem["parent_post_id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
                 val parentCommentId = timelineItem["parent_comment_id"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
                 val parentAuthorUsername = timelineItem["parent_author_username"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
+                val replyToUsernames = timelineItem["reply_to_usernames"]?.jsonArray
+                    ?.mapNotNull { (it as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull }
+                    ?: listOfNotNull(parentAuthorUsername)
                 val createdAt = timelineItem["created_at"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
                 val timestamp = timelineItem["timestamp"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.longOrNull ?: 0L
                 val likeCount = timelineItem["likes_count"]?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.intOrNull ?: 0
@@ -179,6 +182,7 @@ class FeedPagingSource(
                     parentPostId = parentPostId,
                     parentCommentId = parentCommentId,
                     parentAuthorUsername = parentAuthorUsername,
+                    replyToUsernames = replyToUsernames,
                     createdAt = createdAt,
                     likeCount = likeCount,
                     commentCount = commentCount

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
@@ -126,14 +126,24 @@ class CommentRemoteDataSource @Inject constructor(
                         put("root_post_id", postId)
                     }
                 ).data
-                // PostgREST returns scalar array as [[...]] — unwrap first element
+                // PostgREST returns text[] as a JSON array: ["user1","user2"]
                 val json = Json.parseToJsonElement(raw)
-                val arr = (json as? JsonArray)?.firstOrNull()?.jsonArray
-                    ?: (json as? JsonArray)
-                arr?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
+                (json as? JsonArray)?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
             } catch (e: Exception) {
                 Log.w(TAG, "get_thread_usernames RPC failed: ${e.message}")
-                emptyList()
+                // Fallback: fetch parent post author directly
+                try {
+                    client.from("posts")
+                        .select(io.github.jan.supabase.postgrest.query.Columns.raw("author_uid, users!posts_author_uid_fkey(username)")) {
+                            filter { eq("id", parentCommentId) }
+                        }
+                        .decodeSingleOrNull<JsonObject>()
+                        ?.get("users")?.jsonObject
+                        ?.get("username")?.jsonPrimitive?.contentOrNull
+                        ?.let { listOf(it) } ?: emptyList()
+                } catch (e2: Exception) {
+                    emptyList()
+                }
             }
         } else {
             emptyList()
@@ -269,6 +279,7 @@ class CommentRemoteDataSource @Inject constructor(
                 updatedAt = data["updated_at"]?.jsonPrimitive?.contentOrNull,
                 likesCount = data["likes_count"]?.jsonPrimitive?.intOrNull ?: 0,
                 repliesCount = data["comments_count"]?.jsonPrimitive?.intOrNull ?: 0,
+                viewsCount = data["views_count"]?.jsonPrimitive?.intOrNull ?: 0,
                 isDeleted = data["is_deleted"]?.jsonPrimitive?.booleanOrNull ?: false,
                 isEdited = data["is_edited"]?.jsonPrimitive?.booleanOrNull ?: false,
                 isPinned = false,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
@@ -30,6 +30,7 @@ class CommentRemoteDataSource @Inject constructor(
             in_reply_to_post_id, root_post_id,
             likes_count, comments_count, views_count,
             is_deleted, is_edited, edited_at, created_at, updated_at,
+            reply_to_usernames,
             users!posts_author_uid_fkey(uid, username, display_name, email, bio, avatar, followers_count, following_count, posts_count, status, account_type, verify, banned)
         """
     }
@@ -107,14 +108,26 @@ class CommentRemoteDataSource @Inject constructor(
         mediaUrl: String?,
         parentCommentId: String?
     ): CommentWithUser? = withContext(Dispatchers.IO) {
-        // In X-style threading: root_post_id is always the original post,
-        // in_reply_to_post_id is the direct parent (post or comment).
         val rootPostId = if (parentCommentId != null) {
-            // Fetch parent's root_post_id to propagate the thread root
             getComment(parentCommentId)?.postId ?: postId
         } else {
             postId
         }
+
+        // Build reply_to_usernames: author of direct parent + any @mentions in content
+        val replyToUsernames = buildSet<String> {
+            val parentId = parentCommentId ?: postId
+            client.from("posts")
+                .select(Columns.raw("users!posts_author_uid_fkey(username)")) {
+                    filter { eq("id", parentId) }
+                }
+                .decodeSingleOrNull<JsonObject>()
+                ?.get("users")?.jsonObject
+                ?.get("username")?.jsonPrimitive?.contentOrNull
+                ?.let { add(it) }
+
+            Regex("@([\\w.]+)").findAll(content).forEach { add(it.groupValues[1]) }
+        }.toList()
 
         val insertData = buildJsonObject {
             put("id", id)
@@ -126,6 +139,7 @@ class CommentRemoteDataSource @Inject constructor(
             put("post_type", "TEXT")
             put("created_at", java.time.Instant.now().toString())
             put("updated_at", java.time.Instant.now().toString())
+            put("reply_to_usernames", buildJsonArray { replyToUsernames.forEach { add(it) } })
         }
 
         client.from("posts")
@@ -244,6 +258,9 @@ class CommentRemoteDataSource @Inject constructor(
                 isEdited = data["is_edited"]?.jsonPrimitive?.booleanOrNull ?: false,
                 isPinned = false,
                 user = parseUserFromJson(data["users"]?.jsonObject),
+                replyToUsernames = data["reply_to_usernames"]?.jsonArray
+                    ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+                    ?: emptyList(),
                 reactionSummary = emptyMap(),
                 userReaction = null
             )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
@@ -7,6 +7,7 @@ import com.synapse.social.studioasinc.domain.model.UserStatus
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.postgrest.query.Columns
 import io.github.jan.supabase.postgrest.query.Order
 import kotlinx.coroutines.Dispatchers
@@ -114,18 +115,27 @@ class CommentRemoteDataSource @Inject constructor(
             postId
         }
 
-        // Build reply_to_usernames: author of direct parent + any @mentions in content
-        val replyToUsernames = buildSet<String> {
-            val parentId = parentCommentId ?: postId
-            client.from("posts")
-                .select(Columns.raw("users!posts_author_uid_fkey(username)")) {
-                    filter { eq("id", parentId) }
+        // Build reply_to_usernames via a single recursive DB query + inline @mentions
+        val ancestorUsernames = try {
+            val raw = client.postgrest.rpc(
+                "get_thread_usernames",
+                buildJsonObject {
+                    put("start_post_id", parentCommentId ?: postId)
+                    put("root_post_id", postId)
                 }
-                .decodeSingleOrNull<JsonObject>()
-                ?.get("users")?.jsonObject
-                ?.get("username")?.jsonPrimitive?.contentOrNull
-                ?.let { add(it) }
+            ).data
+            // PostgREST returns scalar array as [[...]] — unwrap first element
+            val json = kotlinx.serialization.json.Json.parseToJsonElement(raw)
+            val arr = (json as? JsonArray)?.firstOrNull()?.jsonArray
+                ?: (json as? JsonArray)
+            arr?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
+        } catch (e: Exception) {
+            Log.w(TAG, "get_thread_usernames RPC failed: ${e.message}")
+            emptyList()
+        }
 
+        val replyToUsernames = buildSet<String> {
+            addAll(ancestorUsernames)
             Regex("@([\\w.]+)").findAll(content).forEach { add(it.groupValues[1]) }
         }.toList()
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/source/CommentRemoteDataSource.kt
@@ -34,6 +34,7 @@ class CommentRemoteDataSource @Inject constructor(
             reply_to_usernames,
             users!posts_author_uid_fkey(uid, username, display_name, email, bio, avatar, followers_count, following_count, posts_count, status, account_type, verify, banned)
         """
+        private val MENTION_REGEX = Regex("@([\\w.]+)")
     }
 
     suspend fun fetchComments(postId: String, limit: Int, offset: Int): List<CommentWithUser> = withContext(Dispatchers.IO) {
@@ -116,27 +117,31 @@ class CommentRemoteDataSource @Inject constructor(
         }
 
         // Build reply_to_usernames via a single recursive DB query + inline @mentions
-        val ancestorUsernames = try {
-            val raw = client.postgrest.rpc(
-                "get_thread_usernames",
-                buildJsonObject {
-                    put("start_post_id", parentCommentId ?: postId)
-                    put("root_post_id", postId)
-                }
-            ).data
-            // PostgREST returns scalar array as [[...]] — unwrap first element
-            val json = kotlinx.serialization.json.Json.parseToJsonElement(raw)
-            val arr = (json as? JsonArray)?.firstOrNull()?.jsonArray
-                ?: (json as? JsonArray)
-            arr?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
-        } catch (e: Exception) {
-            Log.w(TAG, "get_thread_usernames RPC failed: ${e.message}")
+        val ancestorUsernames = if (parentCommentId != null) {
+            try {
+                val raw = client.postgrest.rpc(
+                    "get_thread_usernames",
+                    buildJsonObject {
+                        put("start_post_id", parentCommentId)
+                        put("root_post_id", postId)
+                    }
+                ).data
+                // PostgREST returns scalar array as [[...]] — unwrap first element
+                val json = Json.parseToJsonElement(raw)
+                val arr = (json as? JsonArray)?.firstOrNull()?.jsonArray
+                    ?: (json as? JsonArray)
+                arr?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
+            } catch (e: Exception) {
+                Log.w(TAG, "get_thread_usernames RPC failed: ${e.message}")
+                emptyList()
+            }
+        } else {
             emptyList()
         }
 
         val replyToUsernames = buildSet<String> {
             addAll(ancestorUsernames)
-            Regex("@([\\w.]+)").findAll(content).forEach { add(it.groupValues[1]) }
+            MENTION_REGEX.findAll(content).forEach { add(it.groupValues[1]) }
         }.toList()
 
         val insertData = buildJsonObject {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/CommentWithUser.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/CommentWithUser.kt
@@ -39,6 +39,9 @@ data class CommentWithUser(
     val user: UserProfile? = null,
 
     @Transient
+    val replyToUsernames: List<String> = emptyList(),
+
+    @Transient
     val userReaction: ReactionType? = null,
     @Transient
     val reactionSummary: Map<ReactionType, Int> = emptyMap()

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/FeedItem.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/FeedItem.kt
@@ -37,6 +37,7 @@ sealed class FeedItem {
         val parentPostId: String?,
         val parentCommentId: String?,
         val parentAuthorUsername: String?,
+        val replyToUsernames: List<String> = emptyList(),
         override val createdAt: String?,
         override val likeCount: Int,
         override val commentCount: Int,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/FeedScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/FeedScreen.kt
@@ -363,7 +363,6 @@ private fun FeedCommentItem(
     val onOptionsClickAction = remember(commentState.post) { { onOptionsClick(commentState.post) } }
     val onPollVote = remember(feedItem.id) { { _: String -> } }
     val onReactionSelected = remember(feedItem.id) { { reaction: com.synapse.social.studioasinc.domain.model.ReactionType -> viewModel.reactToComment(feedItem.id, reaction) } }
-    val onParentAuthorClick = remember(feedItem.id) { { /* Navigate to parent author */ } }
 
     PostCard(
         state = commentState,
@@ -379,7 +378,6 @@ private fun FeedCommentItem(
         onMediaClick = onMediaClickAction,
         onOptionsClick = onOptionsClickAction,
         onPollVote = onPollVote,
-        onReactionSelected = onReactionSelected,
-        onParentAuthorClick = onParentAuthorClick
+        onReactionSelected = onReactionSelected
     )
 }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/FeedViewModel.kt
@@ -91,7 +91,7 @@ class FeedViewModel @Inject constructor(
             val modifiedPost = modifications[feedItem.id]
             if (modifiedPost != null) {
                 when (feedItem) {
-                    is FeedItem.PostItem -> FeedItem.PostItem(modifiedPost)
+                    is FeedItem.PostItem -> feedItem.copy(post = modifiedPost)
                     is FeedItem.CommentItem -> feedItem.copy(
                         likeCount = modifiedPost.likesCount,
                         isLiked = modifiedPost.userReaction == ReactionType.LIKE || modifiedPost.hasUserReacted()

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/home/home/HomeScreen.kt
@@ -94,33 +94,7 @@ fun HomeScreen(
         Scaffold(
             modifier = if (isPostDetail) Modifier else Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
             contentWindowInsets = if (isPostDetail) WindowInsets(0, 0, 0, 0) else ScaffoldDefaults.contentWindowInsets,
-            floatingActionButton = {
-                if (!isPostDetail && isFeedScreen) {
-                    with(sharedTransitionScope) {
-                        FloatingActionButton(
-                            onClick = { onNavigateToCreatePost(null) },
-                            shape = CircleShape,
-                            containerColor = MaterialTheme.colorScheme.primary,
-                            contentColor = MaterialTheme.colorScheme.onPrimary,
-                            modifier = Modifier
-                                .padding(bottom = if (isBottomBarVisible) 0.dp else Sizes.HeightMedium)
-                                .sharedBounds(
-                                    rememberSharedContentState(key = "create_post_fab"),
-                                    animatedVisibilityScope = animatedVisibilityScope
-                                )
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Add,
-                                contentDescription = stringResource(R.string.create_post),
-                                modifier = Modifier.sharedElement(
-                                    rememberSharedContentState(key = "create_post_icon"),
-                                    animatedVisibilityScope = animatedVisibilityScope
-                                )
-                            )
-                        }
-                    }
-                }
-            },
+            floatingActionButton = {},
             topBar = {
                 if (!isPostDetail) {
                     TopAppBar(
@@ -186,6 +160,36 @@ fun HomeScreen(
             )
         }
 
+
+        if (!isPostDetail && isFeedScreen) {
+            with(sharedTransitionScope) {
+                FloatingActionButton(
+                    onClick = { onNavigateToCreatePost(null) },
+                    shape = CircleShape,
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(end = Spacing.Medium, bottom = Sizes.HeightLarge)
+                        .graphicsLayer {
+                            translationY = navBarTranslationY * size.height
+                        }
+                        .sharedBounds(
+                            rememberSharedContentState(key = "create_post_fab"),
+                            animatedVisibilityScope = animatedVisibilityScope
+                        )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = stringResource(R.string.create_post),
+                        modifier = Modifier.sharedElement(
+                            rememberSharedContentState(key = "create_post_icon"),
+                            animatedVisibilityScope = animatedVisibilityScope
+                        )
+                    )
+                }
+            }
+        }
 
         NavigationBar(
             modifier = Modifier

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
@@ -418,11 +418,14 @@ class ChatViewModel @Inject constructor(
                 }
                 with(messagingDelegate) { current.replaceById(newMessage.id, mergedMessage) }
             } else {
-                // 2. Check if this resolves a pending optimistic message
+                // 2. Check if this resolves a pending optimistic message.
+                // Match by content first so rapid multi-send doesn't misfire across messages.
+                // Fall back to any same-sender pending temp only when content is encrypted (not yet decrypted).
                 val tempId = messagingDelegate.pendingTempIds.value.firstOrNull { id ->
-                    current.any { it.id == id && it.senderId == newMessage.senderId }
-                    // Additional check: maybe compare content hash or message type?
-                    // For now, if we sent something and a message arrives from us, we assume it might be the resolution.
+                    val tempMsg = current.find { it.id == id } ?: return@firstOrNull false
+                    tempMsg.senderId == newMessage.senderId &&
+                        (tempMsg.content == newMessage.content ||
+                            newMessage.content in encryptedPlaceholders)
                 }
 
                 if (tempId != null && newMessage.senderId == currentUserId) {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatInputBar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatInputBar.kt
@@ -397,6 +397,7 @@ fun ChatInputBar(
                     modifier = Modifier
                         .weight(1f)
                         .padding(horizontal = Spacing.Small)
+                        .padding(vertical = Spacing.Small)
                         .focusRequester(focusRequester)
                         .onFocusChanged { isFocused = it.isFocused },
                     enabled = canSendMessage,
@@ -406,7 +407,7 @@ fun ChatInputBar(
                     ),
                     cursorBrush = SolidColor(Color(0xFF4CAF50)),
                     decorationBox = { innerTextField ->
-                        Box(contentAlignment = Alignment.CenterStart) {
+                        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
                             if (inputText.isEmpty()) {
                                 Text(
                                     text = stringResource(R.string.chat_type_message),

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatInputBar.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/ChatInputBar.kt
@@ -39,6 +39,10 @@ import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Stop
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
@@ -310,7 +314,7 @@ fun ChatInputBar(
                     horizontalArrangement = Arrangement.spacedBy(Spacing.ExtraSmall)
                 ) {
                     val isCanceling = slideOffset < -100f
-                    val cancelColor = if (isCanceling) MaterialTheme.colorScheme.error else Color.White.copy(alpha = 0.5f)
+                    val cancelColor = if (isCanceling) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
 
                     val shakeOffset = if (isCanceling) {
                         val infiniteTransition = rememberInfiniteTransition(label = "shake")
@@ -349,7 +353,7 @@ fun ChatInputBar(
                 .fillMaxWidth(inputWidthFraction)
                 .align(Alignment.CenterHorizontally),
             shape = RoundedCornerShape(Sizes.CornerMassive),
-            color = Color(0xFF1E1E1E),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
             tonalElevation = Sizes.BorderDefault,
             shadowElevation = Spacing.ExtraSmall
         ) {
@@ -365,7 +369,7 @@ fun ChatInputBar(
                         Icon(
                             Icons.Default.Add,
                             contentDescription = "Attach file",
-                            tint = Color.White
+                            tint = MaterialTheme.colorScheme.onSurface
                         )
                     }
                     if (showAttachmentMenu) {
@@ -396,23 +400,51 @@ fun ChatInputBar(
                     onValueChange = onInputTextChange,
                     modifier = Modifier
                         .weight(1f)
+                        .defaultMinSize(minHeight = Sizes.InputButtonCompact)
                         .padding(horizontal = Spacing.Small)
-                        .padding(vertical = Spacing.Small)
+                        .padding(vertical = Spacing.ExtraSmall)
                         .focusRequester(focusRequester)
-                        .onFocusChanged { isFocused = it.isFocused },
+                        .onFocusChanged { isFocused = it.isFocused }
+                        .graphicsLayer {
+                            compositingStrategy = if (size.height > 90.dp.toPx()) {
+                                CompositingStrategy.Offscreen
+                            } else {
+                                CompositingStrategy.Auto
+                            }
+                        }
+                        .drawWithContent {
+                            drawContent()
+                            if (size.height > 90.dp.toPx()) {
+                                val fadeSize = 16.dp.toPx()
+                                drawRect(
+                                    brush = Brush.verticalGradient(
+                                        colors = listOf(Color.Transparent, Color.Black),
+                                        startY = 0f, endY = fadeSize
+                                    ),
+                                    blendMode = BlendMode.DstIn
+                                )
+                                drawRect(
+                                    brush = Brush.verticalGradient(
+                                        colors = listOf(Color.Black, Color.Transparent),
+                                        startY = size.height - fadeSize, endY = size.height
+                                    ),
+                                    blendMode = BlendMode.DstIn
+                                )
+                            }
+                        },
                     enabled = canSendMessage,
                     maxLines = 4,
                     textStyle = MaterialTheme.typography.bodyLarge.copy(
-                        color = Color.White
+                        color = MaterialTheme.colorScheme.onSurface
                     ),
-                    cursorBrush = SolidColor(Color(0xFF4CAF50)),
+                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                     decorationBox = { innerTextField ->
                         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
                             if (inputText.isEmpty()) {
                                 Text(
                                     text = stringResource(R.string.chat_type_message),
                                     style = MaterialTheme.typography.bodyLarge,
-                                    color = Color.White.copy(alpha = 0.5f)
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
                                 )
                             }
                             innerTextField()
@@ -502,7 +534,7 @@ fun ChatInputBar(
                             }
                         },
                     shape = CircleShape,
-                    color = Color(0xFF4CAF50),
+                    color = MaterialTheme.colorScheme.primary,
                     contentColor = MaterialTheme.colorScheme.onPrimary
                 ) {
                     Box(contentAlignment = Alignment.Center) {
@@ -523,7 +555,7 @@ fun ChatInputBar(
                                 targetIcon,
                                 contentDescription = stringResource(if (inputText.isEmpty()) R.string.voice_hold_to_record else R.string.chat_action_send),
                                 modifier = Modifier.size(Sizes.IconLarge),
-                                tint = Color.White
+                                tint = MaterialTheme.colorScheme.onPrimary
                             )
                         }
                     }
@@ -537,7 +569,7 @@ fun ChatInputBar(
             Text(
                 text = stringResource(R.string.only_admins_can_message_hint),
                 style = MaterialTheme.typography.labelSmall,
-                color = Color.White.copy(alpha = 0.5f),
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                 modifier = Modifier.align(Alignment.CenterHorizontally).padding(top = Spacing.ExtraSmall)
             )
         }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageContextMenu.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/components/MessageContextMenu.kt
@@ -2,21 +2,12 @@ package com.synapse.social.studioasinc.feature.inbox.inbox.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.ui.Alignment
-
-
-
 import androidx.compose.foundation.background
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.automirrored.filled.Forward
-import androidx.compose.material.icons.automirrored.filled.Reply
-import androidx.compose.material.icons.filled.AddTask
-import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.HelpOutline
-import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.MarkChatUnread
-import androidx.compose.material.icons.filled.MoveToInbox
 import androidx.compose.material.icons.filled.PushPin
-import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -29,10 +20,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-
 import androidx.compose.material3.MaterialTheme
-
-
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
@@ -42,7 +30,6 @@ import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.stringResource
@@ -63,16 +50,9 @@ fun MessageContextMenu(
     onDeleteMessageForMe: (String) -> Unit,
     onDeleteMessageForEveryone: (String) -> Unit,
     onSummarizeMessage: (String) -> Unit,
-    onReplyInThread: () -> Unit = {},
-    onQuoteInReply: () -> Unit = {},
     onForwardMessage: () -> Unit = {},
     onMarkAsUnread: () -> Unit = {},
-    onStarMessage: () -> Unit = {},
-    onPinToBoard: () -> Unit = {},
-    onAddToTasks: () -> Unit = {},
-    onForwardToInbox: () -> Unit = {},
-    onCopyMessageLink: () -> Unit = {},
-    onSendFeedback: () -> Unit = {}
+    onPinToBoard: () -> Unit = {}
 ) {
     if (selectedMessage == null) return
 
@@ -112,8 +92,6 @@ fun MessageContextMenu(
 
             HorizontalDivider()
 
-            // Options
-
             val isFromMe = selectedMessage.senderId == currentUserId
 
             @Composable
@@ -146,7 +124,6 @@ fun MessageContextMenu(
                 }
             }
 
-            // Group 1
             if (isFromMe) {
                 ActionRow(
                     icon = Icons.Default.Edit,
@@ -158,22 +135,6 @@ fun MessageContextMenu(
                 )
             }
             ActionRow(
-                icon = Icons.Default.Forum,
-                text = "Reply in thread",
-                onClick = {
-                    onReplyInThread()
-                    onDismissRequest()
-                }
-            )
-            ActionRow(
-                icon = Icons.AutoMirrored.Filled.Reply,
-                text = "Quote in reply",
-                onClick = {
-                    onQuoteInReply()
-                    onDismissRequest()
-                }
-            )
-            ActionRow(
                 icon = Icons.AutoMirrored.Filled.Forward,
                 text = "Forward message",
                 onClick = {
@@ -184,20 +145,11 @@ fun MessageContextMenu(
 
             HorizontalDivider()
 
-            // Group 2
             ActionRow(
                 icon = Icons.Default.MarkChatUnread,
                 text = "Mark as unread",
                 onClick = {
                     onMarkAsUnread()
-                    onDismissRequest()
-                }
-            )
-            ActionRow(
-                icon = Icons.Default.StarBorder,
-                text = "Star",
-                onClick = {
-                    onStarMessage()
                     onDismissRequest()
                 }
             )
@@ -210,22 +162,6 @@ fun MessageContextMenu(
                 }
             )
             ActionRow(
-                icon = Icons.Default.AddTask,
-                text = "Add to Tasks",
-                onClick = {
-                    onAddToTasks()
-                    onDismissRequest()
-                }
-            )
-            ActionRow(
-                icon = Icons.Default.MoveToInbox,
-                text = "Forward to inbox",
-                onClick = {
-                    onForwardToInbox()
-                    onDismissRequest()
-                }
-            )
-            ActionRow(
                 icon = Icons.Default.ContentCopy,
                 text = "Copy text",
                 onClick = {
@@ -233,26 +169,9 @@ fun MessageContextMenu(
                     onDismissRequest()
                 }
             )
-            ActionRow(
-                icon = Icons.Default.Link,
-                text = "Copy message link",
-                onClick = {
-                    onCopyMessageLink()
-                    onDismissRequest()
-                }
-            )
 
             HorizontalDivider()
 
-            // Group 3
-            ActionRow(
-                icon = Icons.Default.HelpOutline,
-                text = "Send feedback on this message",
-                onClick = {
-                    onSendFeedback()
-                    onDismissRequest()
-                }
-            )
             ActionRow(
                 icon = Icons.Default.Delete,
                 text = "Delete",

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailScreen.kt
@@ -324,6 +324,7 @@ private fun PostDetailContent(
                     onUserClick = onUserClick,
                     onViewReplies = onViewReplies,
                     onCommentClick = onCommentClick,
+                    onCommentViewed = { viewModel.trackCommentView(it) },
                     modifier = Modifier.fillMaxSize(),
                     headerContent = {
                         if (uiState.rootComment != null) {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailScreen.kt
@@ -251,6 +251,7 @@ fun PostDetailScreen(
             onUserClick = onNavigateToProfile,
             onViewReplies = { },
             onCommentClick = { commentId -> onNavigateToCommentDetail(postId, commentId) },
+            onCommentViewed = { viewModel.trackCommentView(it) },
             onPostLike = { _ -> viewModel.toggleReaction(ReactionType.LIKE) },
             onPostComment = { _ ->
                 scope.launch {
@@ -284,6 +285,7 @@ private fun PostDetailContent(
     onUserClick: (String) -> Unit,
     onViewReplies: (String) -> Unit,
     onCommentClick: (String) -> Unit,
+    onCommentViewed: (String) -> Unit,
     onPostLike: (com.synapse.social.studioasinc.domain.model.Post) -> Unit,
     onPostComment: (com.synapse.social.studioasinc.domain.model.Post) -> Unit,
     onPostShare: (com.synapse.social.studioasinc.domain.model.Post) -> Unit,
@@ -324,7 +326,7 @@ private fun PostDetailContent(
                     onUserClick = onUserClick,
                     onViewReplies = onViewReplies,
                     onCommentClick = onCommentClick,
-                    onCommentViewed = { viewModel.trackCommentView(it) },
+                    onCommentViewed = onCommentViewed,
                     modifier = Modifier.fillMaxSize(),
                     headerContent = {
                         if (uiState.rootComment != null) {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailViewModel.kt
@@ -122,6 +122,12 @@ class PostDetailViewModel @Inject constructor(
         }
     }
 
+    fun trackCommentView(commentId: String) {
+        viewModelScope.launch {
+            postDetailRepository.incrementCommentViewCount(commentId)
+        }
+    }
+
     fun refreshComments() {
         val postId = currentPostId ?: return
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/PostDetailViewModel.kt
@@ -122,9 +122,17 @@ class PostDetailViewModel @Inject constructor(
         }
     }
 
+    private val pendingViewedCommentIds = mutableSetOf<String>()
+    private var flushViewsJob: kotlinx.coroutines.Job? = null
+
     fun trackCommentView(commentId: String) {
-        viewModelScope.launch {
-            postDetailRepository.incrementCommentViewCount(commentId)
+        pendingViewedCommentIds.add(commentId)
+        flushViewsJob?.cancel()
+        flushViewsJob = viewModelScope.launch {
+            kotlinx.coroutines.delay(2_000)
+            val batch = pendingViewedCommentIds.toList()
+            pendingViewedCommentIds.clear()
+            batch.forEach { postDetailRepository.incrementCommentViewCount(it) }
         }
     }
 

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/components/CommentsList.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/components/CommentsList.kt
@@ -44,6 +44,7 @@ fun CommentsList(
     modifier: Modifier = Modifier,
     headerContent: @Composable () -> Unit = {}
 ) {
+    val viewedCommentIds = remember { mutableSetOf<String>() }
 
     LazyColumn(
         modifier = modifier.fillMaxSize()
@@ -86,7 +87,9 @@ fun CommentsList(
             val comment = comments[index]
             if (comment != null) {
                 LaunchedEffect(comment.id) {
-                    onCommentViewed?.invoke(comment.id)
+                    if (viewedCommentIds.add(comment.id)) {
+                        onCommentViewed?.invoke(comment.id)
+                    }
                 }
                 val postCardState = PostUiMapper.toPostCardState(
                     comment = comment,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/components/CommentsList.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/components/CommentsList.kt
@@ -40,6 +40,7 @@ fun CommentsList(
     onShowOptions: (CommentWithUser) -> Unit,
     onUserClick: (String) -> Unit,
     onShareClick: ((String) -> Unit)? = null,
+    onCommentViewed: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier,
     headerContent: @Composable () -> Unit = {}
 ) {
@@ -84,7 +85,9 @@ fun CommentsList(
         items(comments.itemCount) { index ->
             val comment = comments[index]
             if (comment != null) {
-                // X (Twitter) style: Flat list, zero indentation.
+                LaunchedEffect(comment.id) {
+                    onCommentViewed?.invoke(comment.id)
+                }
                 val postCardState = PostUiMapper.toPostCardState(
                     comment = comment,
                     parentAuthorUsername = null,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/components/ReplyIndicator.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/components/ReplyIndicator.kt
@@ -31,7 +31,7 @@ fun ReplyIndicator(
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = stringResource(id = R.string.replying_to_user, replyTo.user?.username ?: "User"),
+                text = stringResource(id = R.string.replying_to_user, "@${replyTo.user?.username ?: "User"}"),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileViewModel.kt
@@ -252,7 +252,7 @@ class ProfileViewModel @Inject constructor(
                 state.copy(
                     posts = state.posts.map {
                         if (it is com.synapse.social.studioasinc.domain.model.Post && it.id == post.id) optimisticPost
-                        else if (it is com.synapse.social.studioasinc.domain.model.FeedItem.PostItem && it.id == post.id) com.synapse.social.studioasinc.domain.model.FeedItem.PostItem(optimisticPost)
+                        else if (it is com.synapse.social.studioasinc.domain.model.FeedItem.PostItem && it.id == post.id) it.copy(post = optimisticPost)
                         else it
                     }
                 )
@@ -271,7 +271,7 @@ class ProfileViewModel @Inject constructor(
                     state.copy(
                         posts = state.posts.map {
                             if (it is com.synapse.social.studioasinc.domain.model.Post && it.id == post.id) post
-                            else if (it is com.synapse.social.studioasinc.domain.model.FeedItem.PostItem && it.id == post.id) com.synapse.social.studioasinc.domain.model.FeedItem.PostItem(post)
+                            else if (it is com.synapse.social.studioasinc.domain.model.FeedItem.PostItem && it.id == post.id) it.copy(post = post)
                             else it
                         }
                     )

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/profile/profile/ProfileViewModel.kt
@@ -205,25 +205,55 @@ class ProfileViewModel @Inject constructor(
             val currentUserId = _state.value.currentUserId
             if (currentUserId.isBlank() || currentUserId == userId) return@launch
 
-            _state.update { it.copy(isFollowLoading = true) }
+            _state.update { s ->
+                s.copy(
+                    isFollowLoading = true,
+                    profileState = (s.profileState as? ProfileUiState.Success)?.let { success ->
+                        success.copy(profile = success.profile.copy(followerCount = success.profile.followerCount + 1))
+                    } ?: s.profileState
+                )
+            }
             followUserUseCase(currentUserId, userId).onSuccess {
                 _state.update { it.copy(isFollowing = true, isFollowLoading = false) }
             }.onFailure {
-                _state.update { it.copy(isFollowLoading = false) }
+                // roll back optimistic increment
+                _state.update { s ->
+                    s.copy(
+                        isFollowLoading = false,
+                        profileState = (s.profileState as? ProfileUiState.Success)?.let { success ->
+                            success.copy(profile = success.profile.copy(followerCount = maxOf(0, success.profile.followerCount - 1)))
+                        } ?: s.profileState
+                    )
+                }
             }
         }
     }
 
     fun unfollowUser(userId: String) {
-         viewModelScope.launch {
+        viewModelScope.launch {
             val currentUserId = _state.value.currentUserId
             if (currentUserId.isBlank() || currentUserId == userId) return@launch
 
-            _state.update { it.copy(isFollowLoading = true) }
+            _state.update { s ->
+                s.copy(
+                    isFollowLoading = true,
+                    profileState = (s.profileState as? ProfileUiState.Success)?.let { success ->
+                        success.copy(profile = success.profile.copy(followerCount = maxOf(0, success.profile.followerCount - 1)))
+                    } ?: s.profileState
+                )
+            }
             unfollowUserUseCase(currentUserId, userId).onSuccess {
                 _state.update { it.copy(isFollowing = false, isFollowLoading = false) }
             }.onFailure {
-                _state.update { it.copy(isFollowLoading = false) }
+                // roll back optimistic decrement
+                _state.update { s ->
+                    s.copy(
+                        isFollowLoading = false,
+                        profileState = (s.profileState as? ProfileUiState.Success)?.let { success ->
+                            success.copy(profile = success.profile.copy(followerCount = success.profile.followerCount + 1))
+                        } ?: s.profileState
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCard.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCard.kt
@@ -69,7 +69,7 @@ data class PostCardState(
     // Comment-specific fields
     val isComment: Boolean = false,
     val parentCommentId: String? = null,
-    val parentAuthorUsername: String? = null,
+    val replyToUsernames: List<String> = emptyList(),
     val repliesCount: Int = 0,
     val depth: Int = 0,
     val showThreadLine: Boolean = false,
@@ -92,7 +92,6 @@ fun PostCard(
     onOptionsClick: () -> Unit,
     onPollVote: (String) -> Unit,
     onReactionSelected: ((ReactionType) -> Unit)? = null,
-    onParentAuthorClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     var showReactionPicker by remember { mutableStateOf(false) }
@@ -194,8 +193,7 @@ fun PostCard(
                     feeling = state.post.metadata?.feeling,
                     locationName = state.post.locationName,
                     taggedPeople = state.post.metadata?.taggedPeople ?: emptyList(),
-                    replyToUsername = state.parentAuthorUsername,
-                    onReplyToClick = onParentAuthorClick
+                    replyToUsernames = state.replyToUsernames
                 )
 
                 // Memoize conditional parameters to avoid recomputation

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCard.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCard.kt
@@ -33,10 +33,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BarChart
 import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.res.stringResource
+import com.synapse.social.studioasinc.R
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -183,11 +186,11 @@ fun PostCard(
 
             Spacer(modifier = Modifier.width(Spacing.SmallMedium))
 
-            // Right Column: Header, Content, Interaction Bar
+            // Right Column: Header, Content
             Column(modifier = Modifier.weight(1f)) {
                 PostHeader(
                     user = state.user,
-                    timestamp = state.formattedTimestamp,
+                    timestamp = if (state.isExpanded) "" else state.formattedTimestamp,
                     onUserClick = onUserClick,
                     onOptionsClick = onOptionsClick,
                     feeling = state.post.metadata?.feeling,
@@ -196,12 +199,9 @@ fun PostCard(
                     replyToUsernames = state.replyToUsernames
                 )
 
-                // Memoize conditional parameters to avoid recomputation
-                val contentMediaUrls = state.mediaUrls
-
                 PostContent(
                     text = state.post.postText,
-                    mediaUrls = contentMediaUrls,
+                    mediaUrls = state.mediaUrls,
                     postViewStyle = postViewStyle,
                     isVideo = state.isVideo,
                     pollQuestion = state.pollQuestion,
@@ -215,16 +215,91 @@ fun PostCard(
                     modifier = Modifier
                 )
 
+                if (!state.isExpanded) {
+                    PostInteractionBar(
+                        isLiked = state.isLiked,
+                        likeCount = state.likeCount,
+                        commentCount = state.commentCount,
+                        repostCount = state.repostCount,
+                        viewsCount = state.viewsCount,
+                        isBookmarked = state.isBookmarked,
+                        isReshared = state.isReshared,
+                        hideLikeCount = state.hideLikeCount,
+                        hideViewsCount = state.hideViewsCount,
+                        onLikeClick = onLikeClick,
+                        onCommentClick = onCommentClick,
+                        onShareClick = onShareClick,
+                        onRepostClick = onRepostClick,
+                        onQuoteClick = onQuoteClick,
+                        onBookmarkClick = onBookmarkClick,
+                        onReactionLongPress = if (onReactionSelected != null) {
+                            { showReactionPicker = true }
+                        } else null
+                    )
+                }
+            }
+        }
+
+        // Expanded (focal post) layout: timestamp + View post activity + full-width action bar
+        if (state.isExpanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacing.SmallMedium)
+            ) {
+                Spacer(modifier = Modifier.height(Spacing.Small))
+                // Timestamp on its own line
+                if (state.formattedTimestamp.isNotBlank()) {
+                    Text(
+                        text = state.formattedTimestamp,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = Spacing.ExtraSmall)
+                    )
+                }
+
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                    thickness = Sizes.BorderHairline
+                )
+
+                // "View post activity" row
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = Spacing.Small),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.BarChart,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.Small))
+                    Text(
+                        text = stringResource(R.string.view_post_activity),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                    thickness = Sizes.BorderHairline
+                )
+
+                // Full-width action bar (counts hidden for focal post, icons only)
                 PostInteractionBar(
                     isLiked = state.isLiked,
                     likeCount = state.likeCount,
                     commentCount = state.commentCount,
                     repostCount = state.repostCount,
-                    viewsCount = state.viewsCount,
+                    viewsCount = 0,
                     isBookmarked = state.isBookmarked,
                     isReshared = state.isReshared,
-                    hideLikeCount = state.hideLikeCount,
-                    hideViewsCount = state.hideViewsCount,
+                    hideLikeCount = true,
+                    hideViewsCount = true,
                     onLikeClick = onLikeClick,
                     onCommentClick = onCommentClick,
                     onShareClick = onShareClick,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCommon.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCommon.kt
@@ -139,7 +139,7 @@ object PostUiMapper {
             // Comment-specific fields
             isComment = true,
             parentCommentId = feedComment.parentCommentId,
-            replyToUsernames = listOfNotNull(feedComment.parentAuthorUsername),
+            replyToUsernames = feedComment.replyToUsernames.ifEmpty { listOfNotNull(feedComment.parentAuthorUsername) },
             repliesCount = feedComment.commentCount,
             depth = 0, // Feed comments are always top-level
             showThreadLine = false, // No thread lines in feed
@@ -190,7 +190,7 @@ object PostUiMapper {
             repostedBy = null,
             isComment = true,
             parentCommentId = comment.parentCommentId,
-            replyToUsernames = listOfNotNull(parentAuthorUsername),
+            replyToUsernames = comment.replyToUsernames,
             repliesCount = comment.repliesCount,
             depth = clampedDepth,
             showThreadLine = showThreadLine,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCommon.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCommon.kt
@@ -139,7 +139,7 @@ object PostUiMapper {
             // Comment-specific fields
             isComment = true,
             parentCommentId = feedComment.parentCommentId,
-            parentAuthorUsername = feedComment.parentAuthorUsername,
+            replyToUsernames = listOfNotNull(feedComment.parentAuthorUsername),
             repliesCount = feedComment.commentCount,
             depth = 0, // Feed comments are always top-level
             showThreadLine = false, // No thread lines in feed
@@ -147,16 +147,6 @@ object PostUiMapper {
         )
     }
 
-    /**
-     * Maps a CommentWithUser to PostCardState for rendering comments using PostCard.
-     * 
-     * @param comment The comment with user information to map
-     * @param parentAuthorUsername Username of the parent comment author (for reply context)
-     * @param depth Nesting depth of the comment (0 for top-level, clamped to MAX_COMMENT_DEPTH)
-     * @param showThreadLine Whether to show the thread line indicator
-     * @param isLastReply Whether this is the last reply in a thread
-     * @return PostCardState configured for comment rendering
-     */
     fun toPostCardState(
         comment: CommentWithUser,
         parentAuthorUsername: String? = null,
@@ -164,10 +154,7 @@ object PostUiMapper {
         showThreadLine: Boolean = false,
         isLastReply: Boolean = false
     ): PostCardState {
-        // Clamp depth to prevent performance degradation with deeply nested comments
         val clampedDepth = depth.coerceIn(0, MAX_COMMENT_DEPTH)
-        
-        // Create User object from CommentWithUser using helper methods
         val user = User(
             uid = comment.userId,
             username = comment.getUsername(),
@@ -175,17 +162,14 @@ object PostUiMapper {
             avatar = comment.getAvatarUrl(),
             verify = comment.user?.isVerified ?: false
         )
-        
-        // Create minimal Post object with comment content and metrics
         val post = Post(
             id = comment.id,
             authorUid = comment.userId,
             postText = comment.content,
-            timestamp = System.currentTimeMillis(), // Will be overridden by formattedTimestamp
+            timestamp = System.currentTimeMillis(),
             likesCount = comment.likesCount,
             replyCount = comment.repliesCount
         )
-        
         return PostCardState(
             post = post,
             user = user,
@@ -204,10 +188,9 @@ object PostUiMapper {
             formattedTimestamp = com.synapse.social.studioasinc.core.util.TimeUtils.getTimeAgo(comment.createdAt),
             isExpanded = false,
             repostedBy = null,
-            // Comment-specific fields
             isComment = true,
             parentCommentId = comment.parentCommentId,
-            parentAuthorUsername = parentAuthorUsername,
+            replyToUsernames = listOfNotNull(parentAuthorUsername),
             repliesCount = comment.repliesCount,
             depth = clampedDepth,
             showThreadLine = showThreadLine,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCommon.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCommon.kt
@@ -190,7 +190,9 @@ object PostUiMapper {
             repostedBy = null,
             isComment = true,
             parentCommentId = comment.parentCommentId,
-            replyToUsernames = comment.replyToUsernames,
+            replyToUsernames = comment.replyToUsernames.ifEmpty {
+                listOfNotNull(parentAuthorUsername)
+            },
             repliesCount = comment.repliesCount,
             depth = clampedDepth,
             showThreadLine = showThreadLine,

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostHeader.kt
@@ -177,25 +177,35 @@ fun PostHeader(
             val visible = replyToUsernames.take(visibleCount)
             val overflow = replyToUsernames.size - visibleCount
 
-            val annotated = buildAnnotatedString {
-                withStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant)) {
-                    append(stringResource(R.string.replying_to, "").trimEnd())
-                    append(" ")
-                }
+            // Build the usernames string first so we can insert it into the localized template
+            val usernamesStr = buildString {
                 visible.forEachIndexed { i, username ->
-                    withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary)) {
-                        append("@$username")
-                    }
-                    if (i < visible.size - 1) {
-                        withStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant)) {
-                            append(", ")
+                    append("@$username")
+                    if (i < visible.size - 1) append(", ")
+                }
+                if (overflow > 0) append(" ${stringResource(R.string.and_n_more, overflow)}")
+            }
+            val fullStr = stringResource(R.string.replying_to, usernamesStr)
+            val usernamesStart = fullStr.indexOf(usernamesStr)
+
+            val annotated = buildAnnotatedString {
+                append(fullStr)
+                if (usernamesStart >= 0) {
+                    // Color prefix (before usernames) as onSurfaceVariant
+                    addStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant), 0, usernamesStart)
+                    // Color each @username span as primary
+                    var searchFrom = usernamesStart
+                    visible.forEach { username ->
+                        val tag = "@$username"
+                        val idx = fullStr.indexOf(tag, searchFrom)
+                        if (idx >= 0) {
+                            addStyle(SpanStyle(color = MaterialTheme.colorScheme.primary), idx, idx + tag.length)
+                            searchFrom = idx + tag.length
                         }
                     }
-                }
-                if (overflow > 0) {
-                    withStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant)) {
-                        append(" ")
-                        append(stringResource(R.string.and_n_more, overflow))
+                    // Color "and N more" as onSurfaceVariant
+                    if (overflow > 0) {
+                        addStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant), searchFrom, fullStr.length)
                     }
                 }
             }

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostHeader.kt
@@ -176,14 +176,14 @@ fun PostHeader(
             val visibleCount = 2
             val visible = replyToUsernames.take(visibleCount)
             val overflow = replyToUsernames.size - visibleCount
+            val andNMore = if (overflow > 0) stringResource(R.string.and_n_more, overflow) else ""
 
-            // Build the usernames string first so we can insert it into the localized template
             val usernamesStr = buildString {
                 visible.forEachIndexed { i, username ->
                     append("@$username")
                     if (i < visible.size - 1) append(", ")
                 }
-                if (overflow > 0) append(" ${stringResource(R.string.and_n_more, overflow)}")
+                if (overflow > 0) append(" $andNMore")
             }
             val fullStr = stringResource(R.string.replying_to, usernamesStr)
             val usernamesStart = fullStr.indexOf(usernamesStr)

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostHeader.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostHeader.kt
@@ -15,6 +15,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
@@ -29,6 +33,7 @@ import com.synapse.social.studioasinc.ui.components.GenderBadge
 import com.synapse.social.studioasinc.ui.components.VerifiedBadge
 import androidx.compose.ui.res.stringResource
 import com.synapse.social.studioasinc.R
+import com.synapse.social.studioasinc.feature.post.postdetail.components.ReplyingToBottomSheet
 import com.synapse.social.studioasinc.feature.shared.theme.Sizes
 import com.synapse.social.studioasinc.feature.shared.theme.Spacing
 
@@ -41,10 +46,10 @@ fun PostHeader(
     taggedPeople: List<User> = emptyList(),
     feeling: FeelingActivity? = null,
     locationName: String? = null,
-    replyToUsername: String? = null,
-    onReplyToClick: (() -> Unit)? = null,
+    replyToUsernames: List<String> = emptyList(),
     modifier: Modifier = Modifier
 ) {
+    var showReplyingToSheet by remember { mutableStateOf(false) }
     Column(
         modifier = modifier.fillMaxWidth()
     ) {
@@ -167,32 +172,52 @@ fun PostHeader(
             )
         }
 
-        if (replyToUsername != null) {
-            Row(
-                modifier = Modifier,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                val replyingToText = androidx.compose.ui.res.stringResource(
-                    com.synapse.social.studioasinc.R.string.replying_to,
-                    ""
-                ).replace("%s", "").trim()
+        if (replyToUsernames.isNotEmpty()) {
+            val visibleCount = 2
+            val visible = replyToUsernames.take(visibleCount)
+            val overflow = replyToUsernames.size - visibleCount
 
-                Text(
-                    text = "$replyingToText ",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Text(
-                    text = "@$replyToUsername",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = if (onReplyToClick != null) {
-                        Modifier.clickable { onReplyToClick() }
-                    } else {
-                        Modifier
+            val annotated = buildAnnotatedString {
+                withStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant)) {
+                    append(stringResource(R.string.replying_to, "").trimEnd())
+                    append(" ")
+                }
+                visible.forEachIndexed { i, username ->
+                    withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary)) {
+                        append("@$username")
                     }
-                )
+                    if (i < visible.size - 1) {
+                        withStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant)) {
+                            append(", ")
+                        }
+                    }
+                }
+                if (overflow > 0) {
+                    withStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant)) {
+                        append(" ")
+                        append(stringResource(R.string.and_n_more, overflow))
+                    }
+                }
             }
+
+            Text(
+                text = annotated,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = if (replyToUsernames.size > visibleCount) {
+                    Modifier.clickable { showReplyingToSheet = true }
+                } else {
+                    Modifier
+                }
+            )
+        }
+
+        if (showReplyingToSheet) {
+            ReplyingToBottomSheet(
+                usernames = replyToUsernames,
+                onDismiss = { showReplyingToSheet = false }
+            )
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -624,6 +624,7 @@ Please explain the following message from %3$s in detail, considering the contex
     <!-- Inline Reply Accessibility -->
     <string name="cancel_reply">Cancel reply</string>
     <string name="replying_to">Replying to %s</string>
+    <string name="and_n_more">and %d more</string>
     <string name="reply_media_preview">Reply media preview</string>
 
     <!-- Create Post -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -503,6 +503,7 @@ Please explain the following message from %3$s in detail, considering the contex
     <string name="like_post">Like post</string>
     <string name="like_post_with_count">Like post, %1$d likes</string>
     <string name="like_post_liked">Unlike post, %1$d likes</string>
+    <string name="view_post_activity">View post activity</string>
     <string name="comment_on_post">Comment on post</string>
     <string name="comment_on_post_with_count">Comment on post, %1$d comments</string>
     <string name="share_post">Share post</string>

--- a/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseCommentRepository.kt
+++ b/shared/src/commonMain/kotlin/com/synapse/social/studioasinc/shared/data/repository/SupabaseCommentRepository.kt
@@ -1,5 +1,6 @@
 package com.synapse.social.studioasinc.shared.data.repository
 
+import com.synapse.social.studioasinc.shared.core.util.AppDispatchers
 import com.synapse.social.studioasinc.shared.data.dto.CommentDto
 import com.synapse.social.studioasinc.shared.data.mapper.CommentMapper
 import com.synapse.social.studioasinc.shared.domain.model.Comment
@@ -10,23 +11,36 @@ import io.github.jan.supabase.postgrest.from
 import io.github.jan.supabase.postgrest.query.Columns
 import io.github.jan.supabase.postgrest.query.Order
 import io.github.jan.supabase.postgrest.query.filter.FilterOperator
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 
+/**
+ * Supabase-backed implementation of [CommentRepository].
+ * Manages comment persistence, retrieval, and soft-deletion using Supabase Postgrest.
+ *
+ * @property supabaseClient The initialized Supabase client for database operations.
+ */
 class SupabaseCommentRepository(
     private val supabaseClient: SupabaseClient
 ) : CommentRepository {
 
-    override suspend fun getComments(postId: String, parentId: String?): Result<List<Comment>> = withContext(Dispatchers.IO) {
+    /**
+     * Fetches a list of comments for a specific post.
+     *
+     * @param postId The ID of the post to fetch comments for.
+     * @param parentId If provided, fetches replies to this comment. If null, fetches top-level comments.
+     * @return A [Result] containing a list of [Comment] objects.
+     */
+    override suspend fun getComments(postId: String, parentId: String?): Result<List<Comment>> = withContext(AppDispatchers.IO) {
         runCatching {
             val response = supabaseClient.from("comments").select(
+                // Joins with the users table to retrieve author profile details in a single query
                 columns = Columns.raw("*, author:users(username, avatar)")
             ) {
                 filter {
                     eq("post_id", postId)
                     if (parentId == null) {
+                        // Filters for comments without a parent to get top-level discussions
                         filter("parent_id", FilterOperator.IS, "null")
                     } else {
                         eq("parent_id", parentId)
@@ -38,7 +52,16 @@ class SupabaseCommentRepository(
         }
     }
 
-    override suspend fun addComment(postId: String, content: String, parentId: String?, mediaUrl: String?): Result<Comment> = withContext(Dispatchers.IO) {
+    /**
+     * Adds a new comment or reply to a post.
+     *
+     * @param postId The ID of the post being commented on.
+     * @param content The text content of the comment.
+     * @param parentId The ID of the parent comment if this is a reply, otherwise null.
+     * @param mediaUrl Optional URL for media attached to the comment.
+     * @return A [Result] containing the newly created [Comment].
+     */
+    override suspend fun addComment(postId: String, content: String, parentId: String?, mediaUrl: String?): Result<Comment> = withContext(AppDispatchers.IO) {
         runCatching {
             val userId = supabaseClient.auth.currentUserOrNull()?.id ?: throw Exception("User not authenticated")
             val commentDto = supabaseClient.from("comments").insert(
@@ -50,15 +73,22 @@ class SupabaseCommentRepository(
                     "media_url" to mediaUrl
                 )
             ) {
+                // Selects the inserted row along with author details for immediate UI update
                 select(columns = Columns.raw("*, author:users(username, avatar)"))
             }.decodeSingle<CommentDto>()
             CommentMapper.toDomain(commentDto)
         }
     }
 
-    override suspend fun deleteComment(commentId: String): Result<Unit> = withContext(Dispatchers.IO) {
+    /**
+     * Performs a soft delete on a comment by marking it as deleted and recording the timestamp.
+     *
+     * @param commentId The ID of the comment to delete.
+     * @return A [Result] indicating success or failure.
+     */
+    override suspend fun deleteComment(commentId: String): Result<Unit> = withContext(AppDispatchers.IO) {
         runCatching {
-            // Soft delete
+            // Soft delete preserves the comment record for audit/threaded context while hiding it from standard views
             supabaseClient.from("comments").update(
                 mapOf(
                     "is_deleted" to true,


### PR DESCRIPTION
### ✨ Feature Description
This PR ships a set of interconnected features and fixes across the post thread, comment, feed, chat, and profile layers.

### 🏗️ Implementation Details

**feat(post): X-style "Replying to" with overflow bottom sheet**
- `PostCardState`: replaced `parentAuthorUsername` with `replyToUsernames: List<String>`
- `PostHeader`: renders "Replying to @a, @b and N more"; tapping overflow opens `ReplyingToBottomSheet`
- `PostCard`: removed `onParentAuthorClick` (handled inside `PostHeader`)
- Mappers: wrap legacy `parentAuthorUsername` into `listOfNotNull` for back-compat

**feat(post): wire `reply_to_usernames` from DB through to UI**
- DB: added `reply_to_usernames text[]` column to `posts`; updated `feed_timeline` view
- `CommentRemoteDataSource`: selects and populates `reply_to_usernames` on insert (parent author + @mentions)
- `FeedPagingSource`: parses array from timeline response
- Mappers: passes `replyToUsernames` through to `PostCardState`

**fix(post): collect all ancestor usernames for deep thread replies**
- Replaced single parent lookup with `get_thread_usernames()` recursive DB function (recursive CTE)
- Replies in `A→B→C` now show "Replying to @a, @b, @c"

**fix(comments): track and display reach/view count for comments**
- DB: fixed `increment_comment_views()` to target `posts` table (was targeting non-existent `comments` table)
- `CommentsList`: fires `LaunchedEffect` per comment id on render → calls `onCommentViewed`
- `PostDetailViewModel`: added `trackCommentView()` → `incrementCommentViewCount`
- `PostDetailScreen`: wired `onCommentViewed` callback

**fix(post): resolve unresolved `viewModel` ref in `PostDetailContent`**
- Added `onCommentViewed: (String) -> Unit` param to `PostDetailContent`; passed from `PostDetailScreen`

**fix(feed): preserve `reshareId` in optimistic updates**
- Constructing `FeedItem.PostItem(post)` from scratch dropped `reshareId`, causing `LazyColumn` duplicate key crash
- Fix: use `feedItem.copy(post = ...)` to retain `reshareId`
- Fixes #223

**feat(profile): animate follower count on follow/unfollow**
- `ProfileViewModel.followUser`: optimistically increments `followerCount`; rolls back on failure
- `ProfileViewModel.unfollowUser`: optimistically decrements `followerCount` (clamped at 0); rolls back on failure
- `AnimatedCounter` in `ProfileHeader` drives the slide animation — no additional UI work needed

**fix(chat): prevent realtime optimistic message misfire**
- Match optimistic temp message by content to avoid duplicate/misfire on realtime echo

**fix(chat): add vertical padding and full-width decoration box to `ChatInputBar`**

### 🖼️ UI/UX
- Thread replies show X-style "Replying to @a, @b and N more" with tappable overflow sheet
- Follower count slides up on follow, down on unfollow via existing `AnimatedCounter`

### 🧪 Verification
- [x] Manual verification performed on all changed flows
- [x] Build passing
- [ ] Unit tests — N/A for UI/animation changes
- [x] Accessibility — N/A (no label changes)

### ✅ Build Status
- [x] Passed

### 🔗 References
- Fixes #223