### PR TITLE
🐞 fix: prevent realtime chat messages from being dropped or not appearing

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/ChatViewModel.kt
@@ -418,11 +418,14 @@ class ChatViewModel @Inject constructor(
                 }
                 with(messagingDelegate) { current.replaceById(newMessage.id, mergedMessage) }
             } else {
-                // 2. Check if this resolves a pending optimistic message
+                // 2. Check if this resolves a pending optimistic message.
+                // Match by content first so rapid multi-send doesn't misfire across messages.
+                // Fall back to any same-sender pending temp only when content is encrypted (not yet decrypted).
                 val tempId = messagingDelegate.pendingTempIds.value.firstOrNull { id ->
-                    current.any { it.id == id && it.senderId == newMessage.senderId }
-                    // Additional check: maybe compare content hash or message type?
-                    // For now, if we sent something and a message arrives from us, we assume it might be the resolution.
+                    val tempMsg = current.find { it.id == id } ?: return@firstOrNull false
+                    tempMsg.senderId == newMessage.senderId &&
+                        (tempMsg.content == newMessage.content ||
+                            newMessage.content in encryptedPlaceholders)
                 }
 
                 if (tempId != null && newMessage.senderId == currentUserId) {


### PR DESCRIPTION
### 🐞 Bug Description
- **Current Behavior:** Messages sometimes don't appear in real-time for the recipient. Sender's own messages also occasionally don't show up until the chat screen is closed and reopened.
- **Expected Behavior:** All messages appear instantly for both sender and recipient via the Supabase Realtime subscription, without requiring a screen refresh.
- **Steps to Reproduce:** Open a DM chat with two users. Have one user rapidly send multiple messages. Some messages fail to appear for the other user or the sender until navigation away and back.

### 🔧 Fix Approach
- **Root cause:** The optimistic temp-ID resolution logic in `handleIncomingMessage` used an overly greedy heuristic — it matched any pending temp message from the same sender, regardless of content. When two messages were in-flight simultaneously, the second realtime echo would consume the first (already-removed) temp ID, causing the actual second message to land in the duplicate-dedup path and get silently dropped.
- **How it was fixed:** Changed the temp-ID lookup in `ChatViewModel.handleIncomingMessage` to match by **content equality** (`tempMsg.content == newMessage.content`), with a fallback to any same-sender pending temp only when the incoming content is an encrypted placeholder (not yet decrypted). This ensures each realtime echo resolves exactly the right optimistic message.
- **Potential Side Effects:** None — the fallback path preserves the existing encrypted-message handling, and non-matching realtime messages (e.g. from the other participant) are unaffected.

### 🧪 Verification
- [x] Bug is reproducible without this change
- [x] Bug is fixed with this change
- [x] Regression testing performed — existing single-message send flow is unaffected
- [ ] Tests added/updated — N/A (unit test would require mocking Supabase realtime)

### ✅ Build Status
- [x] Passed

### 🔗 References
- Fixes #163