### PR TITLE
🐞 fix: add missing @ prefix to username in ReplyIndicator

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/components/ReplyIndicator.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/post/postdetail/components/ReplyIndicator.kt
@@ -31,7 +31,7 @@ fun ReplyIndicator(
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = stringResource(id = R.string.replying_to_user, replyTo.user?.username ?: "User"),
+                text = stringResource(id = R.string.replying_to_user, "@${replyTo.user?.username ?: "User"}"),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )


### PR DESCRIPTION
## Bug Description
The reply indicator banner in post detail showed "Replying to johndoe" instead of "Replying to @johndoe".

## Fix Approach
Added `@` prefix when interpolating the username into the `replying_to_user` string resource in `ReplyIndicator.kt`.

```kotlin
// Before
stringResource(id = R.string.replying_to_user, replyTo.user?.username ?: "User")

// After
stringResource(id = R.string.replying_to_user, "@${replyTo.user?.username ?: "User"}")
```

## Verification
- [x] Tapping reply on a comment shows "Replying to @username" in the indicator bar
- [x] Fallback still shows "Replying to @User" if user profile is null

## Build Status
- [x] No new imports, no logic changes — 1 line diff

## References
N/A