### PR TITLE
✨ fix(feed): show replying to usernames on reply posts

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
@@ -143,6 +143,12 @@ class FeedPagingSource(
                                 post.latestCommentAuthor = commentUser?.get("username")?.let { if (it is kotlinx.serialization.json.JsonPrimitive) it else null }?.contentOrNull
                             }
                         }
+                        // Read reply_to_usernames stored on the post row (full list, not just parent)
+                        val storedReplyUsernames = jsonElement["reply_to_usernames"]?.jsonArray
+                            ?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+                        if (!storedReplyUsernames.isNullOrEmpty()) {
+                            post.replyToUsernames = storedReplyUsernames
+                        }
                         post.id to post
                     } catch (e: Exception) {
                         null
@@ -150,9 +156,10 @@ class FeedPagingSource(
                 }.toMap()
             } else emptyMap()
 
-            // Link replyToUsernames for reply posts using the already-fetched postsMap
-            // For parents not in this page, batch-fetch their usernames
+            // For reply posts that don't already have reply_to_usernames stored, fall back
+            // to looking up the single parent author username
             val missingParentIds = postsMap.values
+                .filter { it.replyToUsernames.isEmpty() && it.inReplyToPostId != null }
                 .mapNotNull { it.inReplyToPostId }
                 .filter { it !in postsMap }
                 .distinct()
@@ -174,6 +181,7 @@ class FeedPagingSource(
             } else emptyMap()
 
             postsMap.values.forEach { post ->
+                if (post.replyToUsernames.isNotEmpty()) return@forEach
                 val parentId = post.inReplyToPostId ?: return@forEach
                 val username = postsMap[parentId]?.username ?: parentUsernameMap[parentId] ?: return@forEach
                 post.replyToUsernames = listOf(username)

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/paging/FeedPagingSource.kt
@@ -150,6 +150,35 @@ class FeedPagingSource(
                 }.toMap()
             } else emptyMap()
 
+            // Link replyToUsernames for reply posts using the already-fetched postsMap
+            // For parents not in this page, batch-fetch their usernames
+            val missingParentIds = postsMap.values
+                .mapNotNull { it.inReplyToPostId }
+                .filter { it !in postsMap }
+                .distinct()
+
+            val parentUsernameMap: Map<String, String> = if (missingParentIds.isNotEmpty()) {
+                try {
+                    withContext(Dispatchers.IO) {
+                        client.from("posts")
+                            .select(Columns.list("id", "author_uid", "users:author_uid(username)")) {
+                                filter { isIn("id", missingParentIds) }
+                            }
+                            .decodeList<JsonObject>()
+                    }.mapNotNull { obj ->
+                        val id = obj["id"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+                        val username = obj["users"]?.jsonObject?.get("username")?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+                        id to username
+                    }.toMap()
+                } catch (_: Exception) { emptyMap() }
+            } else emptyMap()
+
+            postsMap.values.forEach { post ->
+                val parentId = post.inReplyToPostId ?: return@forEach
+                val username = postsMap[parentId]?.username ?: parentUsernameMap[parentId] ?: return@forEach
+                post.replyToUsernames = listOf(username)
+            }
+
             // Map and enrich posts
             val postsList = postsMap.values.toList()
             val postsWithReactions = reactionRepository.populatePostReactions(postsList)

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/ProfilePostsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/ProfilePostsRepositoryImpl.kt
@@ -194,6 +194,11 @@ internal class ProfilePostsRepositoryImpl(
             post.isVerified = userData.getBoolean(KEY_VERIFY)
         }
 
+        data["reply_to_usernames"]?.jsonArray
+            ?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { post.replyToUsernames = it }
+
         data[KEY_MEDIA_ITEMS]?.takeIf { it !is JsonNull }?.jsonArray?.let { mediaData ->
             post.mediaItems = mediaData.mapNotNull { item ->
                 val mediaMap = item.jsonObject

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/Post.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/domain/model/Post.kt
@@ -189,6 +189,8 @@ data class Post(
     val isReshared: Boolean = false,
     @Transient
     val resharedByUsername: String? = null,
+    @Transient
+    var replyToUsernames: List<String> = emptyList(),
 
     @SerialName("metadata")
     val metadata: PostMetadata? = null

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCommon.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/shared/components/post/PostCommon.kt
@@ -83,7 +83,8 @@ object PostUiMapper {
             userPollVote = post.userPollVote,
             formattedTimestamp = com.synapse.social.studioasinc.core.util.TimeUtils.getTimeAgo(post.publishDate ?: post.createdAt ?: ""),
             isExpanded = isExpanded,
-            repostedBy = post.resharedByUsername ?: if (post.isReshared) "You" else null
+            repostedBy = post.resharedByUsername ?: if (post.isReshared) "You" else null,
+            replyToUsernames = post.replyToUsernames.ifEmpty { listOfNotNull(post.inReplyToPost?.username?.takeIf { it.isNotBlank() }) }
         )
     }
 


### PR DESCRIPTION
## Feature Description
Reply posts in the home feed now display 'Replying to @username' below the author name.

## Implementation Details
- Added `@Transient var replyToUsernames` field to `Post` domain model
- `FeedPagingSource` batch-fetches parent post author usernames for reply posts whose parents are not in the current page
- `PostUiMapper.toPostCardState(Post)` wires `post.replyToUsernames` into `PostCardState`

## Verification
- [x] Reply posts in feed show 'Replying to @username'
- [x] Posts without a parent are unaffected

## Build Status
- [ ] `./gradlew build` passes

## References
N/A