### PR TITLE
fix: add missing import for rememberSaveable in ChatScreen.kt

### DIFF
--- a/.jules/code-review.md
+++ b/.jules/code-review.md
@@ -48,3 +48,9 @@
   1. rost-block: Thread Safety violation. The `generateSmartReplies` method executes a network request using Ktor's `httpClient.post` without switching to `AppDispatchers.IO`. In Kotlin Multiplatform, this can block the main thread depending on the engine configuration.
   2. rost-warn: Brittle response parsing. The logic to clean replies (`replace(Regex("^[\\s\\d.*-]+\\s*"), "")`) is highly dependent on Gemini following the prompt exactly. It should be more robust or include fallback logic if the response format varies.
   3. suggestion: The API key is retrieved directly from `SynapseConfig`. While acceptable for internal use, for better testability and security, it should be injected through the constructor or a configuration provider.
+
+## app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
+- **Review Strength:** ROST (Max Level)
+- **Status:** Passed
+- **Key Findings:**
+  1. Resolved unresolved reference error by adding missing import for `androidx.compose.runtime.saveable.rememberSaveable`. This is a straightforward fix for a compilation failure.

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/feature/inbox/inbox/screens/ChatScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.text.TextLayoutResult
 
 import androidx.compose.runtime.mutableStateOf


### PR DESCRIPTION
Added the missing import 'androidx.compose.runtime.saveable.rememberSaveable' to resolve a compilation error in ChatScreen.kt. This fix addresses the 'Unresolved reference: rememberSaveable' error reported during the :app:compileReleaseKotlin task.

---
*PR created automatically by Jules for task [12435378024435364269](https://jules.google.com/task/12435378024435364269) started by @TheRealAshik*