### PR TITLE
🐞 fix(user): avatar not showing when loaded from cache

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/data/repository/UserRepositoryImpl.kt
@@ -72,8 +72,8 @@ class UserRepositoryImpl @Inject constructor(
             // First try to get from cache
             var user = userDao.getUserById(userId)?.let { UserMapper.toModel(it) }
             
-            // If not in cache or cache is stale, fetch from Supabase
-            if (user == null) {
+            // If not in cache or cache is missing avatar, fetch from Supabase
+            if (user == null || user?.avatar == null) {
                 val userProfile = client.from(SharedSupabaseClient.TABLE_USERS)
                     .select() {
                         filter {


### PR DESCRIPTION
## Bug Description
The avatar beside "What's on your mind?" (and anywhere `getUserById` is called) showed the initial-letter fallback even after the user had set a profile picture. Once a `UserEntity` row existed in Room with `avatarUrl = null`, the cache-first logic in `getUserById` never re-fetched from Supabase, serving the null avatar indefinitely.

## Fix Approach
Add `|| user?.avatar == null` to the network-fetch condition so a cached user with no avatar still triggers a fresh Supabase lookup and updates the cache.

## Verification
- [x] Set a profile picture, cold-start the app → avatar shows in QuickPostArea immediately
- [x] User already cached with avatar → single cache hit, no extra network call

## Build Status
- [ ] `./gradlew build` passes

## References
N/A