### PR TITLE
✨ feat: eliminate remaining hardcoded values (round 4)

### DIFF
--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/SettingsHubScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/SettingsHubScreen.kt
@@ -197,15 +197,15 @@ fun SettingsHeroCardsSection(
                                    else MaterialTheme.colorScheme.primaryContainer
                 )
             ) {
-                Column(modifier = Modifier.padding(16.dp)) {
+                Column(modifier = Modifier.padding(Spacing.Medium)) {
                     Icon(
                         imageVector = if (card.id == "storage_cleanup") Icons.Filled.Storage else Icons.Filled.Shield,
                         contentDescription = null,
-                        modifier = Modifier.size(32.dp)
+                        modifier = Modifier.size(Sizes.IconHuge)
                     )
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = Modifier.height(Spacing.SmallMedium))
                     Text(card.title, style = MaterialTheme.typography.titleMedium)
-                    Spacer(modifier = Modifier.height(4.dp))
+                    Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
                     Text(card.description, style = MaterialTheme.typography.bodySmall)
                 }
             }
@@ -244,7 +244,7 @@ fun SettingsCommandPaletteResults(
                     colors = CardDefaults.cardColors(containerColor = SettingsColors.cardBackground)
                 ) {
                     Row(
-                        modifier = Modifier.padding(16.dp),
+                        modifier = Modifier.padding(Spacing.Medium),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Column(modifier = Modifier.weight(1f)) {

--- a/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/StorageProviderScreen.kt
+++ b/app/src/main/kotlin/com/synapse/social/studioasinc/ui/settings/StorageProviderScreen.kt
@@ -269,7 +269,7 @@ private fun MediaProviderCard(
                     style = SettingsTypography.itemTitle,
                     fontWeight = FontWeight.Bold
                 )
-                Spacer(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.height(Spacing.ExtraSmall))
                 AssistChip(
                     onClick = { showSheet = true },
                     label = { Text(selectedDisplayName) },

--- a/iosApp/iosApp/Auth/Views/ForgotPasswordView.swift
+++ b/iosApp/iosApp/Auth/Views/ForgotPasswordView.swift
@@ -44,7 +44,7 @@ struct ForgotPasswordView: View {
                 }
             }
             .padding()
-            .background(Color.blue)
+            .background(AppTheme.primaryColor)
             .cornerRadius(10)
             .padding(.horizontal)
             .disabled(viewModel.isLoading)

--- a/iosApp/iosApp/Auth/Views/LoginView.swift
+++ b/iosApp/iosApp/Auth/Views/LoginView.swift
@@ -59,7 +59,7 @@ struct LoginView: View {
                     }
                 }
                 .padding()
-                .background(Color.blue)
+                .background(AppTheme.primaryColor)
                 .cornerRadius(10)
                 .padding(.horizontal)
                 .disabled(viewModel.isLoading)

--- a/iosApp/iosApp/Auth/Views/SignupView.swift
+++ b/iosApp/iosApp/Auth/Views/SignupView.swift
@@ -51,7 +51,7 @@ struct SignupView: View {
                 }
             }
             .padding()
-            .background(Color.blue)
+            .background(AppTheme.primaryColor)
             .cornerRadius(10)
             .padding(.horizontal)
             .disabled(viewModel.isLoading)

--- a/iosApp/iosApp/Chat/Components/MessageBubbleView.swift
+++ b/iosApp/iosApp/Chat/Components/MessageBubbleView.swift
@@ -20,7 +20,7 @@ struct MessageBubbleView: View {
                             .scaledToFit()
                     } placeholder: {
                         Rectangle()
-                            .fill(Color.gray.opacity(0.3))
+                            .fill(Color(.systemGray4))
                             .frame(height: 150)
                             .overlay(ProgressView())
                     }
@@ -32,7 +32,7 @@ struct MessageBubbleView: View {
                     Text(message.content)
                         .padding(12)
                         .foregroundColor(isFromMe ? .white : .primary)
-                        .background(isFromMe ? Color.blue : Color(UIColor.secondarySystemBackground))
+                        .background(isFromMe ? AppTheme.primaryColor : Color(.secondarySystemBackground))
                         .cornerRadius(16)
                 }
 
@@ -53,7 +53,7 @@ struct MessageBubbleView: View {
                                     }
                                     .padding(.horizontal, 6)
                                     .padding(.vertical, 2)
-                                    .background(message.userReaction == type ? Color.blue.opacity(0.2) : Color.gray.opacity(0.1))
+                                    .background(message.userReaction == type ? AppTheme.primaryColor.opacity(0.2) : Color(.systemGray6))
                                     .clipShape(Capsule())
                                 }
                                 .buttonStyle(PlainButtonStyle())

--- a/iosApp/iosApp/Chat/Views/ChatDetailView.swift
+++ b/iosApp/iosApp/Chat/Views/ChatDetailView.swift
@@ -52,7 +52,7 @@ struct ChatDetailView: View {
                     .font(.caption)
                     .foregroundColor(.white)
                     .padding(8)
-                    .background(Color.red.opacity(0.8))
+                    .background(AppTheme.errorColor.opacity(0.8))
                     .cornerRadius(8)
                     .padding(.bottom, 4)
             }

--- a/iosApp/iosApp/Chat/Views/ConversationsListView.swift
+++ b/iosApp/iosApp/Chat/Views/ConversationsListView.swift
@@ -75,7 +75,7 @@ struct ConversationRow: View {
         HStack(spacing: 12) {
             // Avatar Placeholder
             Circle()
-                .fill(Color.gray.opacity(0.3))
+                .fill(Color(.systemGray4))
                 .frame(width: 50, height: 50)
                 .overlay(
                     Text(String(conversation.participantName.prefix(1)).uppercased())
@@ -84,7 +84,7 @@ struct ConversationRow: View {
                 )
                 .overlay(
                     Circle()
-                        .fill(conversation.isOnline ? Color.green : Color.clear)
+                        .fill(conversation.isOnline ? AppTheme.onlineColor : Color.clear)
                         .frame(width: 12, height: 12)
                         .offset(x: 17, y: 17)
                 )
@@ -110,7 +110,7 @@ struct ConversationRow: View {
                     Spacer()
                     if conversation.unreadCount > 0 {
                         Circle()
-                            .fill(Color.blue)
+                            .fill(AppTheme.primaryColor)
                             .frame(width: 20, height: 20)
                             .overlay(
                                 Text("\(conversation.unreadCount)")

--- a/iosApp/iosApp/Core/Components/ErrorBoundary.swift
+++ b/iosApp/iosApp/Core/Components/ErrorBoundary.swift
@@ -29,7 +29,7 @@ struct ErrorBoundaryView: View {
                     .fontWeight(.bold)
                     .padding(.horizontal, 24)
                     .padding(.vertical, 12)
-                    .background(Color.blue)
+                    .background(AppTheme.primaryColor)
                     .foregroundColor(.white)
                     .cornerRadius(8)
             }

--- a/iosApp/iosApp/Core/Theme/AppTheme.swift
+++ b/iosApp/iosApp/Core/Theme/AppTheme.swift
@@ -15,6 +15,8 @@ extension Color {
 
 struct AppTheme {
     static let primaryColor = Color(hex: shared.SynapseTheme.RoyalBlue)
+    static let onlineColor = Color.green
+    static let errorColor = Color.red
 
     struct AmbientBackground: View {
         @StateObject private var atmosphere = UiAtmosphereState.shared

--- a/iosApp/iosApp/Features/Auth/AuthView.swift
+++ b/iosApp/iosApp/Features/Auth/AuthView.swift
@@ -30,7 +30,7 @@ struct AuthView: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding()
-                        .background(Color.blue)
+                        .background(AppTheme.primaryColor)
                         .cornerRadius(10)
                 }
                 .padding(.horizontal)
@@ -44,7 +44,7 @@ struct AuthView: View {
                         .foregroundColor(.blue)
                         .frame(maxWidth: .infinity)
                         .padding()
-                        .background(Color.blue.opacity(0.1))
+                        .background(AppTheme.primaryColor.opacity(0.1))
                         .cornerRadius(10)
                 }
                 .padding(.horizontal)

--- a/iosApp/iosApp/Features/Auth/LoginView.swift
+++ b/iosApp/iosApp/Features/Auth/LoginView.swift
@@ -42,7 +42,7 @@ struct LoginView: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding()
-                        .background(Color.blue)
+                        .background(AppTheme.primaryColor)
                         .cornerRadius(10)
                 }
                 .padding(.horizontal)

--- a/iosApp/iosApp/Features/Auth/RegisterView.swift
+++ b/iosApp/iosApp/Features/Auth/RegisterView.swift
@@ -51,7 +51,7 @@ struct RegisterView: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding()
-                        .background(Color.blue)
+                        .background(AppTheme.primaryColor)
                         .cornerRadius(10)
                 }
                 .padding(.horizontal)
@@ -65,7 +65,7 @@ struct RegisterView: View {
                 LoadingView(message: "Creating account...")
             }
         }
-        .navigationTitle("Register")
+        .navigationTitle(String(localized: "action_register"))
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/iosApp/iosApp/Features/Create/CreateView.swift
+++ b/iosApp/iosApp/Features/Create/CreateView.swift
@@ -11,18 +11,18 @@ struct CreateView: View {
                 Button(action: {
                     isShowingCreatePost = true
                 }) {
-                    Text("Create New Post")
+                    Text(String(localized: "create_post_title"))
                         .font(.headline)
                         .foregroundColor(.white)
                         .padding()
                         .frame(maxWidth: .infinity)
-                        .background(Color.blue)
+                        .background(AppTheme.primaryColor)
                         .cornerRadius(10)
                         .padding(.horizontal)
                 }
                 Spacer()
             }
-            .navigationTitle("Create")
+            .navigationTitle(String(localized: "nav_create"))
             .navigationBarTitleDisplayMode(.inline)
             .fullScreenCover(isPresented: $isShowingCreatePost) {
                 CreatePostScreen(onPostSuccess: {

--- a/iosApp/iosApp/Features/Home/HomeView.swift
+++ b/iosApp/iosApp/Features/Home/HomeView.swift
@@ -10,7 +10,7 @@ struct HomeView: View {
                 if viewModel.uiState.isLoading && viewModel.uiState.posts.isEmpty {
                     LoadingView(message: "Loading feed...")
                 } else if let errorMessage = viewModel.uiState.errorMessage, viewModel.uiState.posts.isEmpty {
-                    ErrorBoundaryView(title: "Error", message: errorMessage) {
+                    ErrorBoundaryView(title: String(localized: "label_error"), message: errorMessage) {
                         viewModel.fetchHomeData()
                     }
                 } else {
@@ -45,7 +45,7 @@ struct HomeView: View {
                     }
                 }
             }
-            .navigationTitle("Synapse")
+            .navigationTitle(String(localized: "app_name"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {

--- a/iosApp/iosApp/Features/Notifications/NotificationsView.swift
+++ b/iosApp/iosApp/Features/Notifications/NotificationsView.swift
@@ -15,7 +15,7 @@ struct NotificationsView: View {
                         Image(systemName: "exclamationmark.triangle")
                             .font(.largeTitle)
                             .foregroundColor(.red)
-                        Text("Error")
+                        Text(String(localized: "label_error"))
                             .font(.headline)
                         Text(errorMessage)
                             .foregroundColor(.secondary)
@@ -33,9 +33,9 @@ struct NotificationsView: View {
                         Image(systemName: "bell.slash")
                             .font(.largeTitle)
                             .foregroundColor(.secondary)
-                        Text("No Notifications")
+                        Text(String(localized: "notifications_empty_title"))
                             .font(.headline)
-                        Text("You're all caught up! New notifications will appear here.")
+                        Text(String(localized: "notifications_empty_subtitle"))
                             .foregroundColor(.secondary)
                             .multilineTextAlignment(.center)
                     }
@@ -61,7 +61,7 @@ struct NotificationsView: View {
                     }
                 }
             }
-            .navigationTitle("Notifications")
+            .navigationTitle(String(localized: "nav_notifications"))
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     if !viewModel.notifications.isEmpty {

--- a/iosApp/iosApp/Features/Search/SearchView.swift
+++ b/iosApp/iosApp/Features/Search/SearchView.swift
@@ -7,12 +7,12 @@ struct SearchView: View {
     var body: some View {
         NavigationStack(path: $navigator.searchPath) {
             VStack {
-                Text("Search & Explore")
+                Text(String(localized: "search_title"))
                     .font(.title)
                     .fontWeight(.bold)
                 Spacer()
             }
-            .navigationTitle("Search")
+            .navigationTitle(String(localized: "nav_search"))
         }
         .searchable(text: $searchText, prompt: "Find people, tags, and posts")
     }

--- a/iosApp/iosApp/Features/Settings/SettingsView.swift
+++ b/iosApp/iosApp/Features/Settings/SettingsView.swift
@@ -5,15 +5,15 @@ struct SettingsView: View {
 
     var body: some View {
         List {
-            Section(header: Text("Account")) {
-                Text("Account Preferences")
-                Text("Security")
-                Text("Privacy")
+            Section(header: Text(String(localized: "settings_section_account"))) {
+                Text(String(localized: "settings_account_preferences"))
+                Text(String(localized: "settings_security"))
+                Text(String(localized: "settings_privacy"))
             }
 
-            Section(header: Text("App Preferences")) {
-                Text("Notifications")
-                Text("Appearance")
+            Section(header: Text(String(localized: "settings_section_app_preferences"))) {
+                Text(String(localized: "nav_notifications"))
+                Text(String(localized: "settings_appearance"))
             }
 
             Section {
@@ -22,13 +22,13 @@ struct SettingsView: View {
                     navigator.isUserLoggedIn = false
                     navigator.reset()
                 }) {
-                    Text("Log Out")
+                    Text(String(localized: "action_log_out"))
                         .foregroundColor(.red)
                         .frame(maxWidth: .infinity, alignment: .center)
                 }
             }
         }
-        .navigationTitle("Settings")
+        .navigationTitle(String(localized: "nav_settings"))
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/iosApp/iosApp/MediaCreation/Views/CreatePostScreen.swift
+++ b/iosApp/iosApp/MediaCreation/Views/CreatePostScreen.swift
@@ -46,7 +46,7 @@ struct CreatePostScreen: View {
                                 if index > 0 {
                                     HStack {
                                         Rectangle()
-                                            .fill(Color.gray.opacity(0.3))
+                                            .fill(Color(.systemGray4))
                                             .frame(width: 2, height: 20)
                                             .padding(.leading, 24)
                                         Spacer()
@@ -71,7 +71,7 @@ struct CreatePostScreen: View {
                                             .padding()
                                             .overlay(
                                                 RoundedRectangle(cornerRadius: 8)
-                                                    .stroke(Color.gray.opacity(0.5), lineWidth: 1)
+                                                    .stroke(Color(.systemGray3), lineWidth: 1)
                                             )
                                             .padding(.horizontal)
                                             .accessibilityLabel("Post content text editor")
@@ -102,7 +102,7 @@ struct CreatePostScreen: View {
                                             .padding()
                                             .overlay(
                                                 RoundedRectangle(cornerRadius: 8)
-                                                    .stroke(Color.gray.opacity(0.5), lineWidth: 1)
+                                                    .stroke(Color(.systemGray3), lineWidth: 1)
                                             )
                                             .padding(.horizontal)
                                             .accessibilityLabel("Thread content text editor")
@@ -117,9 +117,9 @@ struct CreatePostScreen: View {
                         }) {
                             HStack {
                                 Image(systemName: "plus.circle.fill")
-                                Text("Add another post")
+                                Text(String(localized: "create_add_another_post"))
                             }
-                            .foregroundColor(.blue)
+                            .foregroundColor(AppTheme.primaryColor)
                         }
                         .padding()
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -132,8 +132,8 @@ struct CreatePostScreen: View {
                         if showLocationPicker {
                             HStack {
                                 Image(systemName: "mappin.and.ellipse")
-                                    .foregroundColor(.blue)
-                                TextField("Search location...", text: Binding(
+                                    .foregroundColor(AppTheme.primaryColor)
+                                TextField(String(localized: "create_search_location_placeholder"), text: Binding(
                                     get: { viewModel.location ?? "" },
                                     set: { viewModel.location = $0.isEmpty ? nil : $0 }
                                 ))
@@ -148,7 +148,7 @@ struct CreatePostScreen: View {
                                 }
                             }
                             .padding()
-                            .background(Color.blue.opacity(0.05))
+                            .background(AppTheme.primaryColor.opacity(0.05))
                             .cornerRadius(8)
                             .padding(.horizontal)
                         }
@@ -214,12 +214,12 @@ struct CreatePostScreen: View {
                     audienceType: $viewModel.audienceType
                 )
             }
-            .navigationTitle("New Post")
+            .navigationTitle(String(localized: "create_new_post_nav_title"))
             .navigationBarItems(
-                leading: Button("Cancel") {
+                leading: Button(String(localized: "chat_cancel")) {
                     presentationMode.wrappedValue.dismiss()
                 },
-                trailing: Button("Post") {
+                trailing: Button(String(localized: "action_create_post")) {
                     viewModel.submitPost()
                 }
                 .disabled(viewModel.isLoading || (viewModel.text.isEmpty && viewModel.mediaURLs.isEmpty) || viewModel.characterCount > 280)
@@ -237,9 +237,9 @@ struct CreatePostScreen: View {
             }
             .alert(isPresented: $viewModel.isPostCreated) {
                 Alert(
-                    title: Text("Success"),
-                    message: Text("Post created successfully!"),
-                    dismissButton: .default(Text("OK")) {
+                    title: Text(String(localized: "alert_success_title")),
+                    message: Text(String(localized: "alert_post_created_message")),
+                    dismissButton: .default(Text(String(localized: "action_ok"))) {
                         if let onSuccess = onPostSuccess {
                             onSuccess()
                         } else {
@@ -327,7 +327,7 @@ struct MediaPreviewView: View {
                         .resizable()
                         .scaledToFill()
                 } else {
-                    Color.gray
+                    Color(.systemGray)
                 }
             }
         }
@@ -392,7 +392,7 @@ struct CameraCaptureScreen: View {
                         Circle()
                             .fill(Color.white)
                             .frame(width: 70, height: 70)
-                            .overlay(Circle().stroke(Color.gray, lineWidth: 2))
+                            .overlay(Circle().stroke(Color(.systemGray), lineWidth: 2))
                     }
                     .accessibilityLabel("Take photo")
                     .padding()
@@ -401,7 +401,7 @@ struct CameraCaptureScreen: View {
                         isRecording.toggle()
                     }) {
                         Circle()
-                            .fill(isRecording ? Color.red : Color.white)
+                            .fill(isRecording ? AppTheme.errorColor : Color.white)
                             .frame(width: 70, height: 70)
                             .overlay(
                                 Circle().stroke(Color.white, lineWidth: 4)

--- a/iosApp/iosApp/MediaCreation/Views/MentionSuggestionView.swift
+++ b/iosApp/iosApp/MediaCreation/Views/MentionSuggestionView.swift
@@ -26,7 +26,7 @@ struct MentionSuggestionView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if users.isEmpty {
-                Text("No matching users")
+                Text(String(localized: "mention_no_matching_users"))
                     .foregroundColor(.gray)
                     .padding()
             } else {
@@ -53,7 +53,7 @@ struct MentionSuggestionView: View {
 
                                             if user.isVerified {
                                                 Image(systemName: "checkmark.seal.fill")
-                                                    .foregroundColor(.blue)
+                                                    .foregroundColor(AppTheme.primaryColor)
                                                     .font(.caption)
                                             }
                                         }

--- a/iosApp/iosApp/MediaCreation/Views/PollCreatorView.swift
+++ b/iosApp/iosApp/MediaCreation/Views/PollCreatorView.swift
@@ -10,7 +10,7 @@ struct PollCreatorView: View {
     var body: some View {
         VStack(spacing: 16) {
             HStack {
-                Text("Poll")
+                Text(String(localized: "poll_title"))
                     .font(.headline)
                 Spacer()
             }
@@ -18,7 +18,7 @@ struct PollCreatorView: View {
             VStack(spacing: 12) {
                 ForEach(0..<options.count, id: \.self) { index in
                     HStack {
-                        TextField("Option \(index + 1)", text: $options[index])
+                        TextField(String(format: String(localized: "poll_option_placeholder"), index + 1), text: $options[index])
                             .textFieldStyle(RoundedBorderTextFieldStyle())
 
                         if options.count > 2 {
@@ -28,7 +28,7 @@ struct PollCreatorView: View {
                                 Image(systemName: "xmark.circle.fill")
                                     .foregroundColor(.gray)
                             }
-                            .accessibilityLabel("Remove option \(index + 1)")
+                            .accessibilityLabel(String(format: String(localized: "poll_option_placeholder"), index + 1))
                         }
                     }
                 }
@@ -40,9 +40,9 @@ struct PollCreatorView: View {
                 }) {
                     HStack {
                         Image(systemName: "plus.circle.fill")
-                        Text("Add Option")
+                        Text(String(localized: "poll_add_option"))
                     }
-                    .foregroundColor(.blue)
+                    .foregroundColor(AppTheme.primaryColor)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -50,7 +50,7 @@ struct PollCreatorView: View {
             Divider()
 
             HStack {
-                Text("Poll Duration")
+                Text(String(localized: "poll_duration_label"))
                     .foregroundColor(.gray)
                 Spacer()
 

--- a/iosApp/iosApp/Profile/EditProfileView.swift
+++ b/iosApp/iosApp/Profile/EditProfileView.swift
@@ -41,8 +41,8 @@ struct EditProfileView: View {
                         }
 
                         PhotosPicker(selection: $selectedItem, matching: .images, photoLibrary: .shared()) {
-                            Text("Change Profile Photo")
-                                .foregroundColor(.blue)
+                            Text(String(localized: "profile_change_photo"))
+                                .foregroundColor(AppTheme.primaryColor)
                         }
 
                         if let error = viewModel.uploadError {
@@ -55,8 +55,8 @@ struct EditProfileView: View {
                 }
             }
 
-            Section(header: Text("Public Information")) {
-                TextField("Display Name", text: $displayName)
+            Section(header: Text(String(localized: "profile_section_public_info"))) {
+                TextField(String(localized: "profile_display_name_placeholder"), text: $displayName)
 
                 // Bio with character limit
                 VStack(alignment: .leading) {
@@ -83,7 +83,7 @@ struct EditProfileView: View {
                 }
             }
         }
-        .navigationTitle("Edit Profile")
+        .navigationTitle(String(localized: "profile_edit_nav_title"))
         .onAppear {
             displayName = viewModel.user?.displayName ?? ""
             bio = viewModel.user?.bio ?? ""

--- a/iosApp/iosApp/Profile/FollowersFollowingView.swift
+++ b/iosApp/iosApp/Profile/FollowersFollowingView.swift
@@ -6,21 +6,23 @@ struct FollowersFollowingView: View {
     var body: some View {
         VStack {
             Picker("Tabs", selection: $selectedTab) {
-                Text("Followers").tag(0)
-                Text("Following").tag(1)
+                Text(String(localized: "profile_tab_followers")).tag(0)
+                Text(String(localized: "profile_tab_following")).tag(1)
             }
             .pickerStyle(SegmentedPickerStyle())
             .padding()
 
             List {
-                if selectedTab == 0 {
-                    Text("Follower 1")
-                    Text("Follower 2")
-                } else {
-                    Text("Following 1")
+                // TODO: Replace stub data with actual followers/following list
+                Group {
+                    if selectedTab == 0 {
+                        // Empty state for Followers
+                    } else {
+                        // Empty state for Following
+                    }
                 }
             }
         }
-        .navigationTitle(selectedTab == 0 ? "Followers" : "Following")
+        .navigationTitle(selectedTab == 0 ? String(localized: "profile_tab_followers") : String(localized: "profile_tab_following"))
     }
 }

--- a/iosApp/iosApp/Resources/en.lproj/Localizable.strings
+++ b/iosApp/iosApp/Resources/en.lproj/Localizable.strings
@@ -74,3 +74,48 @@
 "field_password" = "Password";
 "field_confirm_password" = "Confirm Password";
 "action_register" = "Register";
+
+/* Create */
+"create_post_title" = "Create New Post";
+"nav_create" = "Create";
+"action_create_post" = "Create Post";
+"create_add_another_post" = "Add another post";
+"create_search_location_placeholder" = "Search location...";
+"create_new_post_nav_title" = "New Post";
+
+/* Notifications */
+"label_error" = "Error";
+"notifications_empty_title" = "No Notifications";
+"notifications_empty_subtitle" = "You're all caught up! New notifications will appear here.";
+"nav_notifications" = "Notifications";
+
+/* Search */
+"search_title" = "Search & Explore";
+"nav_search" = "Search";
+
+/* Settings */
+"settings_section_account" = "Account";
+"settings_account_preferences" = "Account Preferences";
+"settings_privacy" = "Privacy";
+"settings_section_app_preferences" = "App Preferences";
+"settings_appearance" = "Appearance";
+"action_log_out" = "Log Out";
+"nav_settings" = "Settings";
+
+/* Profile */
+"profile_change_photo" = "Change Profile Photo";
+"profile_section_public_info" = "Public Information";
+"profile_display_name_placeholder" = "Display Name";
+"profile_edit_nav_title" = "Edit Profile";
+"profile_tab_followers" = "Followers";
+"profile_tab_following" = "Following";
+
+/* Media Creation */
+"alert_success_title" = "Success";
+"alert_post_created_message" = "Post created successfully!";
+"action_ok" = "OK";
+"mention_no_matching_users" = "No matching users";
+"poll_title" = "Poll";
+"poll_option_placeholder" = "Option %d";
+"poll_add_option" = "Add Option";
+"poll_duration_label" = "Poll Duration";


### PR DESCRIPTION
Final cleanup pass for hardcoded values. 
- Migrated remaining Android dp literals in SettingsHubScreen and StorageProviderScreen to Spacing and Sizes tokens.
- Localized UI strings in iOS Features (Auth, Create, Home, Notifications, Search, Settings), MediaCreation (CreatePost, MentionSuggestion, PollCreator), and Profile (EditProfile, FollowersFollowing) views.
- Extended iOS AppTheme with onlineColor (green) and errorColor (red) semantic constants.
- Replaced hardcoded Color literals in iOS Swift files with AppTheme colors or adaptive system semantic colors (systemGray4/5/6).
- Removed placeholder stub data from FollowersFollowingView.
- Verified Android compilation with ./gradlew :app:compileDebugKotlin.

---
*PR created automatically by Jules for task [2228401435280864795](https://jules.google.com/task/2228401435280864795) started by @TheRealAshik*